### PR TITLE
fix subject LaboratoryResultObservation (given patient iso bundle path)

### DIFF
--- a/ada_2_fhir/zibs2017/payload/zib-LaboratoryTestResult-Observation-2.1.xsl
+++ b/ada_2_fhir/zibs2017/payload/zib-LaboratoryTestResult-Observation-2.1.xsl
@@ -188,7 +188,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                     </code>
                 </xsl:for-each>
                 <!-- NL-CM:0.0.12			Patient -->
-                <xsl:for-each select="ancestor::*[bundle]/bundle/subject">
+                <xsl:for-each select="$adaPatient">
                     <subject>
                         <xsl:apply-templates select="." mode="doPatientReference-2.1"/>
                     </subject>


### PR DESCRIPTION
In LaboratoryTestResultObservation wordt de referentie naar Patient gebaseerd op een specifiek ADA pad in plaats van de (meegegeven) ADA Patient parameter