### PR TITLE
feat: auto generate message id if magic value "generate_id" is specified

### DIFF
--- a/ada_2_hl7/peri/2_3/kernset_geboortezorg/wrapper/kernset_geboortezorg_wrapper.xsl
+++ b/ada_2_hl7/peri/2_3/kernset_geboortezorg/wrapper/kernset_geboortezorg_wrapper.xsl
@@ -61,7 +61,14 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                     <xsl:attribute name="xsi:schemaLocation" select="./@value"/>
                 </xsl:for-each>
                 <xsl:for-each select="./id">
-                    <xsl:call-template name="makeId"/>
+                    <xsl:choose>
+                        <xsl:when test="@value='generate_id'">
+                            <id extension="{concat(translate(substring(xs:string(current-dateTime()), 1, 19), 'T:.-', ''), $input_xml_payload_doc//burgerservicenummer/@value/string())}" root="{@root}"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:call-template name="makeId"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:for-each>
                 <xsl:for-each select="./creation_time">
                     <creationTime>


### PR DESCRIPTION
If a magic `generate_id` value is specified in the message id in the wrapper, it gets replaced with an automatically generated value.

This was a feature available in ada_2_hl7/peri/2_2/kernset_aanleverbericht/wrapper/kernset_aanleverbericht_wrapper.xsl, but was not yet available in 2_3. This PR ports this functionality over.