### PR TITLE
Move the logic of building metadata for sub instances up a level.

### DIFF
--- a/ada_2_fhir-r4/fhir/2_fhir_fhir_include.xsl
+++ b/ada_2_fhir-r4/fhir/2_fhir_fhir_include.xsl
@@ -14,9 +14,9 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
 -->
 
 <xsl:stylesheet exclude-result-prefixes="#all" xmlns="http://hl7.org/fhir" xmlns:f="http://hl7.org/fhir" xmlns:uuid="http://www.uuid.org" xmlns:local="urn:fhir:stu3:functions" xmlns:nf="http://www.nictiz.nl/functions" xmlns:nm="http://www.nictiz.nl/mappings" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:util="urn:hl7:utilities" version="2.0">
-    
+
     <xsl:import href="../../ada_2_fhir/fhir/2_fhir_fhir_include.xsl"/>
-    
+
     <xd:doc>
         <xd:desc>
             When $populateId equals true(), Resource.id will be filled. It will be filled with @logicalId if it is present in the ada-element or generated if no @logicalId is present.
@@ -26,14 +26,14 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
         </xd:desc>
     </xd:doc>
     <xsl:param name="populateId" select="true()" as="xs:boolean"/>
-    
+
 
     <xd:doc>
         <xd:desc>$referencingStrategy will be filled with one of the following values: <xd:ul>
-            <xd:li>logicalId</xd:li>
-            <xd:li>uuid</xd:li>
-            <xd:li>none</xd:li>
-        </xd:ul>
+                <xd:li>logicalId</xd:li>
+                <xd:li>uuid</xd:li>
+                <xd:li>none</xd:li>
+            </xd:ul>
             When $referencingStrategy equals 'logicalId', the value of $populateId is ignored. A Resource.id is added to the resource, with its value being populated from (in this order) @logicalId on the root of the ada element being referenced or from a template with mode '_generateId'. It is the responsibility of the use case XSLT to extract the fullUrl from $fhirMetadata. Should not be used when there is no FHIR server available to retrieve the resources.
             When $referencingStrategy equals 'uuid', all referencing is done using uuids. It is the responsibility of the use case XSLT to extract the fullUrl from $fhirMetadata. Meant for use within Bundles. Be sure to include all referenced resources in the Bundle! 
             When $referencingStrategy equals 'none', it is attempted to generate a Reference from an identifier being present in the referenced ada-element. If this is not possible, referencing fails.
@@ -42,7 +42,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
         </xd:desc>
     </xd:doc>
     <xsl:param name="referencingStrategy" select="'uuid'" as="xs:string"/>
-    
+
     <xd:doc>
         <xd:desc>The server base URI for creating logical references.</xd:desc>
     </xd:doc>
@@ -132,12 +132,12 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
 
     <xsl:variable name="zib2020Oid" select="'2.16.840.1.113883.2.4.3.11.60.40.1'"/>
     <xsl:param name="fhirVersion" select="'R4'"/>
-    
+
     <xd:doc>
         <xd:param name="patientTokensXml">Override optional parameter containing XML document based on QualificationTokens.json as used on Github / Touchstone</xd:param>
     </xd:doc>
     <xsl:param name="patientTokensXml" select="document('../../ada_2_fhir/fhir/QualificationTokens.xml')"/>
-    
+
     <xd:doc>
         <xd:desc>Build the metadata for all the FHIR resources that are to be generated from the current input.</xd:desc>
     </xd:doc>
@@ -145,8 +145,8 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
         <xsl:call-template name="buildFhirMetadata">
             <xsl:with-param name="in" select="/*"/>
         </xsl:call-template>
-    </xsl:param>   
-    
+    </xsl:param>
+
     <xd:doc>
         <xd:desc>Build the FHIR metadata for the resources that shall result from the transformation of the specified ADA instances. This metadata may then be used when building the actual FHIR instances for building references and Bundle's. For each generated FHIR instance, the FHIR metadata will be stored in an nm:resource element and may contain the following elements:
             <xd:ul>
@@ -164,35 +164,56 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     </xd:doc>
     <xsl:template name="buildFhirMetadata">
         <xsl:param name="in"/>
-        
+
         <xsl:if test="not($referencingStrategy = ('logicalId', 'uuid', 'none'))">
             <xsl:message terminate="yes">Invalid $referencingStrategy. Should be one of 'logicalId', 'uuid', 'none'</xsl:message>
         </xsl:if>
-        
+
         <xsl:for-each-group select="$in[self::patient[.//(@value | @code | @nullFlavor)]]" group-by="concat((identificatienummer[@root = $oidBurgerservicenummer], identificatienummer[not(@root = $oidBurgerservicenummer)])[1]/@root, (identificatienummer[@root = $oidBurgerservicenummer], identificatienummer[not(@root = $oidBurgerservicenummer)])[1]/normalize-space(@value))">
             <xsl:for-each-group select="current-group()" group-by="nf:getGroupingKeyDefault(.)">
                 <xsl:call-template name="_buildFhirMetadataForAdaEntry"/>
             </xsl:for-each-group>
         </xsl:for-each-group>
-        
-        <!-- General rule for concepts -->
-        <xsl:for-each-group select="$in[not(self::patient)][.//(@value | @code | @nullFlavor)]" group-by="nf:getGroupingKeyDefault(.)">
+
+        <xsl:for-each-group select="$in[self::zorgverlener[.//(@value | @code | @nullFlavor)]]" group-by="
+            concat(nf:ada-zvl-id(zorgverlener_identificatienummer)/@root,
+            nf:ada-zvl-id(zorgverlener_identificatienummer)/normalize-space(@value))">
+            <xsl:for-each-group select="current-group()" group-by="nf:getGroupingKeyDefault(.)">
             <xsl:call-template name="_buildFhirMetadataForAdaEntry"/>
         </xsl:for-each-group>
+        </xsl:for-each-group>
         
-        <xsl:for-each select="$in[not(.//(@value | @code | @nullFlavor))][not(ends-with(local-name(),'-start'))]">
+        <!-- General rule for all zib root concepts that need to be converted into a FHIR resource -->
+        <xsl:for-each-group select="(
+              $in[not(self::patient or self::zorgverlener)],
+              $in//horen_hulpmiddel/medisch_hulpmiddel,
+              $in//zien_hulpmiddel/medisch_hulpmiddel,
+              $in//product[parent::medisch_hulpmiddel],
+              $in//visueel_resultaat[parent::tekst_uitslag],
+              $in//soepregel[parent::soepverslag]
+            )[.//(@value | @code | @nullFlavor)]" group-by="local-name()">
+            <xsl:for-each-group select="current-group()" group-by="nf:getGroupingKeyDefault(.)">
+                <xsl:call-template name="_buildFhirMetadataForAdaEntry">
+                    <xsl:with-param name="partNumber" select="position()"/>
+                </xsl:call-template>
+            </xsl:for-each-group>
+        </xsl:for-each-group>
+
+        <xsl:for-each select="$in[not(.//(@value | @code | @nullFlavor))][not(ends-with(local-name(), '-start'))]">
             <xsl:message>Error: no meaningful content found in <xsl:value-of select="replace(tokenize(base-uri(), '/')[last()], '.xml', '')"/> - <xsl:value-of select="local-name()"/></xsl:message>
         </xsl:for-each>
-        
+
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Helper template to build the FHIR metadata for a singe ADA instance. See the documentation on <xd:ref name="buildFhirMetadata" type="template"/> for more information.</xd:desc>
         <xd:param name="in">The ADA instance to generate metadata for.</xd:param>
+        <xd:param name="partNumber">The sequence number of the ADA instance being passed in the total collection of ADA instances of this kind. This sequence number is needed for ids in resources that represent just a part of a zib.</xd:param>
     </xd:doc>
     <xsl:template name="_buildFhirMetadataForAdaEntry" as="element(nm:resource)*">
         <xsl:param name="in" select="current-group()[1]"/>
-        
+        <xsl:param name="partNumber" as="xs:integer" select="0"/>
+
         <xsl:variable name="adaElement" as="xs:string" select="$in/local-name()"/>
         <xsl:variable name="adaId" select="$in/@id"/>
         <xsl:variable name="groupKey" select="current-grouping-key()"/>
@@ -225,7 +246,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                         <xsl:when test="$in/@logicalId">
                             <xsl:choose>
                                 <xsl:when test="count($ada2resourceType/nm:map[@ada = $adaElement]) gt 1">
-                                    <xsl:value-of select="concat($in/@logicalId,'-',@resource)"/>
+                                    <xsl:value-of select="concat($in/@logicalId, '-', @resource)"/>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <xsl:value-of select="$in/@logicalId"/>
@@ -235,6 +256,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                         <xsl:otherwise>
                             <xsl:apply-templates select="$in" mode="_generateId">
                                 <xsl:with-param name="profile" select="$profile"/>
+                                <xsl:with-param name="partNumber" select="$partNumber"/>
                             </xsl:apply-templates>
                         </xsl:otherwise>
                     </xsl:choose>
@@ -244,7 +266,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                         <xsl:value-of select="$logicalId"/>
                     </nm:logical-id>
                 </xsl:if>
-                
+
                 <xsl:choose>
                     <xsl:when test="$in/@referenceUri">
                         <nm:full-url>
@@ -294,37 +316,8 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 </nm:reference-display>
             </nm:resource>
         </xsl:for-each>
-        
-        <!-- HearingFunction.HearingAid::MedicalDevice, VisualFunction.VisualAid::MedicalDevice, MedicalDevice::Product, SOAPReport::SOAPLine and TextResult::VisualResult are special cases, where a single concept leads to a separate resource, therefore we have to build separate entries for these concepts -->
-        <xsl:choose>
-            <xsl:when test="$in/self::functie_horen">
-                <xsl:for-each-group select="$in/horen_hulpmiddel/medisch_hulpmiddel" group-by="nf:getGroupingKeyDefault(.)">
-                    <xsl:call-template name="_buildFhirMetadataForAdaEntry"/>
-                </xsl:for-each-group>
-            </xsl:when>
-            <xsl:when test="$in/self::functie_zien">
-                <xsl:for-each-group select="$in/zien_hulpmiddel/medisch_hulpmiddel" group-by="nf:getGroupingKeyDefault(.)">
-                    <xsl:call-template name="_buildFhirMetadataForAdaEntry"/>
-                </xsl:for-each-group>
-            </xsl:when>
-            <xsl:when test="$in/self::medisch_hulpmiddel">
-                <xsl:for-each-group select="$in/product" group-by="nf:getGroupingKeyDefault(.)">
-                    <xsl:call-template name="_buildFhirMetadataForAdaEntry"/>
-                </xsl:for-each-group>
-            </xsl:when>
-            <xsl:when test="$in/self::soepverslag">
-                <xsl:for-each-group select="$in/soepregel" group-by="nf:getGroupingKeyDefault(.)">
-                    <xsl:call-template name="_buildFhirMetadataForAdaEntry"/>
-                </xsl:for-each-group>
-            </xsl:when>
-            <xsl:when test="$in/self::tekst_uitslag">
-                <xsl:for-each-group select="$in/visueel_resultaat" group-by="nf:getGroupingKeyDefault(.)">
-                    <xsl:call-template name="_buildFhirMetadataForAdaEntry"/>
-                </xsl:for-each-group>
-            </xsl:when>
-        </xsl:choose>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Helper template for creating logicalId</xd:desc>
         <xd:param name="uniqueString">The unique string with which to create a logical id. Optional. If not given a uuid will be generated.</xd:param>
@@ -345,7 +338,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
 
     <xd:doc>
         <xd:desc>Generate a FHIR reference. When there's no input or a reference can't otherwise be constructed, no output is generated.</xd:desc>
-        
+
         <xd:param name="in">The target of the reference as either an ADA instance or an ADA reference element. May be omitted if it is the same as the context.</xd:param>
         <xd:param name="profile">The id of the profile that is targeted. This is needed to specify which profile is targeted when a single ADA instance is mapped onto multiple FHIR profiles. It may be omitted otherwise.</xd:param>
         <xd:param name="wrapIn">Optional element name to wrap the output in. If no output is generated, this wrapper will not be generated as well.</xd:param>
@@ -365,14 +358,14 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
         <xsl:variable name="groupKey">
             <xsl:choose>
                 <xsl:when test="$in[@datatype = 'reference' and @value] and not(empty(nf:resolveAdaInstance($in, /)))">
-                    <xsl:value-of select="nf:getGroupingKeyDefault(nf:resolveAdaInstance($in,/))"/>
+                    <xsl:value-of select="nf:getGroupingKeyDefault(nf:resolveAdaInstance($in, /))"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:value-of select="nf:getGroupingKeyDefault($in)"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        
+
         <xsl:variable name="element" as="element()?">
             <xsl:choose>
                 <xsl:when test="count($fhirMetadata[nm:group-key = $groupKey]) gt 1">
@@ -400,7 +393,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 <xsl:with-param name="level" select="$logERROR"/>
                 <xsl:with-param name="msg">Cannot resolve reference within set of ada-instances: <xsl:value-of select="$groupKey"/></xsl:with-param>
             </xsl:call-template>
-        </xsl:if>
+          </xsl:if>
 
         <xsl:variable name="populatedReference" as="element()*">
             <xsl:if test="string-length($element/nm:ref-url) gt 0">
@@ -447,7 +440,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
             </xsl:choose>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Insert the FHIR resource id element for the specified ADA instance, if an id is required (see the <xd:ref name="populateId" type="parameter"/> and <xd:ref name="referencingStrategy" type="parameter"/> parameters).
         </xd:desc>
@@ -457,19 +450,19 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     <xsl:template name="insertLogicalId">
         <xsl:param name="in" select="."/>
         <xsl:param name="profile" as="xs:string" select="''"/>
-        
+
         <xsl:variable name="logicalId">
             <xsl:call-template name="getLogicalIdFromFhirMetadata">
                 <xsl:with-param name="in" select="$in"/>
                 <xsl:with-param name="profile" select="$profile"/>
             </xsl:call-template>
         </xsl:variable>
-        
+
         <xsl:if test="string-length($logicalId) gt 0">
             <id value="{$logicalId}"/>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Get the FHIR resource id element for the specified ADA instance, if an id is available (see the <xd:ref name="populateId" type="parameter"/> and <xd:ref name="referencingStrategy" type="parameter"/> parameters).
         </xd:desc>
@@ -479,13 +472,13 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     <xsl:template name="getLogicalIdFromFhirMetadata">
         <xsl:param name="in" select="."/>
         <xsl:param name="profile" as="xs:string" select="''"/>
-        
+
         <xsl:variable name="groupKey" select="nf:getGroupingKeyDefault($in)"/>
-        
+
         <xsl:if test="count($fhirMetadata[nm:group-key = $groupKey]) gt 1 and string-length($profile) = 0">
             <xsl:message terminate="yes">insertId: Duplicate entry found in $fhirMetadata, while no $profile was supplied. $groupKey: <xsl:value-of select="$groupKey"/></xsl:message>
         </xsl:if>
-        
+
         <xsl:variable name="logicalId">
             <xsl:choose>
                 <xsl:when test="count($fhirMetadata[nm:group-key = $groupKey]) gt 1">
@@ -496,27 +489,27 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        
+
         <xsl:if test="string-length($logicalId) gt 0">
             <xsl:value-of select="$logicalId"/>
         </xsl:if>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Insert the FHIR fullUrl element for the specified instance, if one is available (see the <xd:ref name="referencingStrategy" type="parameter"/> parameter).</xd:desc>
         <xd:param name="in">The ADA instance that the FHIR resource is generated for.</xd:param>
         <xd:param name="profile">The id of the profile that is being generated from the specified ADA instance. This is needed to specify which profile is targeted when a single ADA instance results is mapped onto multiple FHIR profiles. It may be omitted otherwise.</xd:param>
-    </xd:doc>    
+    </xd:doc>
     <xsl:template name="insertFullUrl">
         <xsl:param name="in" select="."/>
         <xsl:param name="profile" as="xs:string" select="''"/>
-        
+
         <xsl:variable name="groupKey" select="nf:getGroupingKeyDefault($in)"/>
-        
-        <xsl:if test="count($fhirMetadata[nm:group-key = $groupKey]) gt 1 and  string-length($profile) = 0">
+
+        <xsl:if test="count($fhirMetadata[nm:group-key = $groupKey]) gt 1 and string-length($profile) = 0">
             <xsl:message terminate="yes">insertFullUrl: Duplicate entry found in $fhirMetadata, while no $profile was supplied.</xsl:message>
         </xsl:if>
-        
+
         <xsl:variable name="fullUrl">
             <xsl:choose>
                 <xsl:when test="count($fhirMetadata[nm:group-key = $groupKey]) gt 1">
@@ -527,14 +520,14 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        
+
         <xsl:if test="string-length($fullUrl) gt 0">
             <fullUrl value="{$fullUrl}"/>
         </xsl:if>
     </xsl:template>
 
     <!-- Generic (fallback) templates, each zib transformation can have more relevant id and display generation mechanisms -->
-    
+
     <xd:doc>
         <xd:desc>Generic template for generating an id for a FHIR resource. Stylesheets for specific zibs can override this with a more specific version.</xd:desc>
         <xd:param name="in">The ADA instance to generate the id for.</xd:param>
@@ -543,7 +536,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     <xsl:template match="*" mode="_generateId">
         <xsl:param name="in" select="."/>
         <xsl:param name="profile" as="xs:string?" select="''"/>
-        
+
         <xsl:variable name="uuidIn" as="element()?">
             <xsl:element name="{$in/local-name()}">
                 <xsl:copy-of select="$in/@*"/>
@@ -551,17 +544,17 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 <xsl:copy-of select="$in/node()"/>
             </xsl:element>
         </xsl:variable>
-        
+
         <xsl:value-of select="nf:assure-logicalid-chars(nf:get-uuid($uuidIn))"/>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Generic template for generating a display for use in FHIR references. Stylesheets for specific zibs can override this with a more specific version.</xd:desc>
         <xd:param name="in">The ADA instance to generate the display for.</xd:param>
     </xd:doc>
     <xsl:template match="*" mode="_generateDisplay">
         <xsl:param name="in" select="."/>
-        
+
         <xsl:choose>
             <xsl:when test="$in//*[ends-with(local-name(.), '_naam')][@value or @displayName or @originalText]">
                 <xsl:value-of select="($in//*[ends-with(local-name(.), '_naam')]/(@displayName, @originalText, @value))[1]"/>
@@ -571,7 +564,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
-    
+
     <xd:doc>
         <xd:desc>Function to resolve internal references in an ADA instance. The output is the contained ADA instance being referenced or the input node if the input node isn't a reference.</xd:desc>
         <xd:param name="in">The ADA instance to resolve.</xd:param>
@@ -580,7 +573,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     <xsl:function name="nf:resolveAdaInstance" as="element()*">
         <xsl:param name="in" as="element()?"/>
         <xsl:param name="context" as="node()"/>
-        
+
         <xsl:choose>
             <xsl:when test="$in[@datatype = 'reference' and @value]">
                 <xsl:variable name="adaId" select="$in/@value"/>
@@ -591,7 +584,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
-    
+
     <xd:doc>
         <xd:desc>Returns a string based on requirements for FHIR logicalId (https://www.hl7.org/fhir/datatypes.html#id). 
             An underscore is translated to '-'. Any other char that is not allowed is simply removed.</xd:desc>
@@ -610,7 +603,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     </xd:doc>
     <xsl:function name="nf:assure-logicalid-length" as="xs:string">
         <xsl:param name="logicalId" as="xs:string?"/>
-        
+
         <xsl:variable name="lengthLogicalId" select="string-length($logicalId)" as="xs:integer"/>
         <xsl:variable name="startingLoc" as="xs:integer">
             <xsl:choose>
@@ -627,14 +620,14 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        
+
         <xsl:value-of select="substring($logicalId, $startingLoc, $lengthLogicalId)"/>
     </xsl:function>
-    
+
     <xd:doc>
         <xd:desc>Returns true (boolean) if the date or dateTime is in the future. Defaults to false. Input should be a value that is castable to a date or dateTime. Input may be empty which results in the default false value.</xd:desc>
         <xd:param name="dateOrDt">The ADA date or dateTime.</xd:param>
-    </xd:doc>    
+    </xd:doc>
     <xsl:function name="nf:isFuture" as="xs:boolean">
         <xsl:param name="dateOrDt"/>
         <xsl:choose>
@@ -649,10 +642,10 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
-    
+
     <xd:doc>
         <xd:desc>Returns true (boolean) if the date or dateTime is in the past. Defaults to false. Input should be a value that is castable to a date or dateTime. Input may be empty which results in the default false value.</xd:desc>
-    </xd:doc>    
+    </xd:doc>
     <xsl:function name="nf:isPast" as="xs:boolean">
         <xsl:param name="dateOrDt"/>
         <xsl:choose>
@@ -667,7 +660,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
-    
+
     <xd:doc>
         <xd:desc>Returns the full profileName for an ada element, based on $urlBaseNictizProfile and $ada2resourceType constant.
             Selects the first one found, which may be wrong if there is more than one entry. In which case you should not use this function.</xd:desc>

--- a/ada_2_fhir-r4/zibs2020/ada_project_drivers/_driverInclude.xsl
+++ b/ada_2_fhir-r4/zibs2020/ada_project_drivers/_driverInclude.xsl
@@ -78,13 +78,16 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     <xd:doc>
         <xd:desc>Override the id generation with the file name of the ADA instance</xd:desc>
         <xd:param name="profile">The id of the profile that is targeted. This is needed to specify which profile is targeted when a single ADA instance results is mapped onto multiple FHIR profiles. It may be omitted otherwise.</xd:param>
+        <xd:param name="partNumber">The sequence number of the ADA instance being passed in the total collection of ADA instances of this kind. This sequence number is needed for ids in resources that represent just a part of a zib.</xd:param>
     </xd:doc>
     <xsl:template match="*" mode="_generateId" priority="2">
         <xsl:param name="profile" as="xs:string" required="yes"/>
+        <xsl:param name="partNumber" as="xs:integer"/>
+        
         <xsl:variable name="id" select="replace(tokenize(base-uri(), '/')[last()], '.xml', '')"/>
         <xsl:variable name="baseId" select="replace($id, '-[0-9]{2}$', '')"/>
         <xsl:variable name="localName" select="local-name()"/>
-        
+
         <xsl:variable name="logicalId">
             <xsl:choose>
                 <xsl:when test="ancestor::*/local-name() = 'referenties'">
@@ -103,7 +106,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                     <xsl:value-of select="$baseId"/>
                     <xsl:value-of select="substring-after($profile, $baseId)"/>
                     <xsl:text>-</xsl:text>
-                    <xsl:value-of select="format-number(count(preceding-sibling::*[local-name() = $localName])+1, '00')"/>
+                    <xsl:value-of select="format-number($partNumber, '00')"/>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:value-of select="$baseId"/>


### PR DESCRIPTION
 This concentrates the selection of ADA instances that need to be converted to a single place and makes is possible to enumerate _all_ of the sub-instances in the complete set.