### PR TITLE
JGZ-324 - fix conversion of 'Notitieblad' and 'Aanvullende opmerkingen'

### DIFF
--- a/hl7_2_hl7/jeugdgezondheidszorg/dossieroverdracht-327-vs-400/dob-327-to-400.xsl
+++ b/hl7_2_hl7/jeugdgezondheidszorg/dossieroverdracht-327-vs-400/dob-327-to-400.xsl
@@ -1564,8 +1564,8 @@
         <xd:desc>Annotation was ACT, but now is OBS. Act.text (ST) is now Act.value (ANY). If ACT.text really is ST, then so is value[@xsi:type=ST]</xd:desc>
     </xd:doc>
     <xsl:template match="
-            hl7:careProvisionEvent/hl7:componentOf7/hl7:*/hl7:*/hl7:annotation/hl7:text |
-            hl7:careProvisionEvent/hl7:componentOf7/hl7:*/hl7:*/hl7:conclusion/hl7:subjectOf/hl7:annotation/hl7:text" mode="dob327">
+            hl7:careProvisionEvent/hl7:component7/hl7:*/hl7:*/hl7:annotation/hl7:text |
+            hl7:careProvisionEvent/hl7:component7/hl7:*/hl7:*/hl7:conclusion/hl7:subjectOf/hl7:annotation/hl7:text" mode="dob327">
         <value xsi:type="ST" xmlns="urn:hl7-org:v3">
             <xsl:value-of select="."/>
         </value>

--- a/hl7_2_hl7/jeugdgezondheidszorg/dossieroverdracht-327-vs-400/dob-400-to-327.xsl
+++ b/hl7_2_hl7/jeugdgezondheidszorg/dossieroverdracht-327-vs-400/dob-400-to-327.xsl
@@ -1471,6 +1471,17 @@
     </xsl:template>
 
     <xd:doc>
+        <xd:desc>Annotation is OBS, but was ACT. Act.value (ANY) was Act.text (ST). If ACT.text really is ST, then so is value[@xsi:type=ST]</xd:desc>
+    </xd:doc>
+    <xsl:template match="
+        hl7:careProvisionEvent/hl7:component7/hl7:*/hl7:*/hl7:annotation/hl7:value |
+        hl7:careProvisionEvent/hl7:component7/hl7:*/hl7:*/hl7:conclusion/hl7:subjectOf/hl7:annotation/hl7:value" mode="dob400">
+        <text xmlns="urn:hl7-org:v3">
+            <xsl:value-of select="."/>
+        </text>
+    </xsl:template>
+    
+    <xd:doc>
         <xd:desc>hl7:subjectOf1/hl7:conclusion/hl7:component/hl7:indication/hl7:reasonOf bevat van actIntent | referral naar actIntent | referral | registrationIntent | observationIntent</xd:desc>
     </xd:doc>
     <xsl:template match="hl7:subjectOf1/hl7:conclusion/hl7:component/hl7:indication/hl7:reasonOf" mode="dob400">


### PR DESCRIPTION
[JGZ-324](https://bits.nictiz.nl/browse/JGZ-324)
The elements of 'Notititeblad' en 'Aanvullende opmerkingen' need to be converted between _text_ and _value_