### PR TITLE
Update link to art decor docs README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains executable mappings to convert between different HL7 formats (like HL7v3 and FHIR) for various Dutch standards for electronic exchange of healthcare information.
 
-These mappings are usually based on XSLT transformations on XML messages. Most of these mappings use a neutral intermediate format called ADA ([ART-DECOR Applications](https://art-decor.org/mediawiki/index.php?title=ADA_Documentation)), which is an extension of the [ART-DECOR tooling](https://art-decor.org/mediawiki/index.php/Main_Page) for specifying electronic healthcare standards. 
+These mappings are usually based on XSLT transformations on XML messages. Most of these mappings use a neutral intermediate format called ADA ([ART-DECOR Applications](https://art-decor.org/mediawiki/index.php?title=ADA_Documentation)), which is an extension of the [ART-DECOR tooling](https://docs.art-decor.org/) for specifying electronic healthcare standards. 
 
 Within Nictiz ADA is used for additional purposes, like generating documentation. These mappings are not part of this public repository.
 


### PR DESCRIPTION
Old link was outdated, according to the page it referred to:
“ This is documentation for ART-DECOR Release 2 and tends to be out-dated. Please visit our new documentation site at docs.art-decor.org” https://wiki.art-decor.org/index.php/Main_Page