### PR TITLE
MM-5022 Updated Resource.id logic

### DIFF
--- a/_ant-buildfiles/ant-publish/build-ketenzorg-3.0.2.xml
+++ b/_ant-buildfiles/ant-publish/build-ketenzorg-3.0.2.xml
@@ -7,7 +7,7 @@
 <project basedir="." default="ketenzorg-3.0.2" name="ADA">
     <property name="project.title" value="Ketenzorg 3.0.2 HL7v3 to ADA to FHIR"/>
     <property name="project.app" value="ketenzorg-3.0.2-hl7v3_2_fhir"/>
-    <property name="project.version" value="1.4.25"/>
+    <property name="project.version" value="1.4.26"/>
     <property name="project.uri" value="https://decor.nictiz.nl/pub/ketenzorg/kz-html-20190110T164948/index.html"/>
     <property name="build.dir" value="${project.title}"/>
     <property name="build.dir.pub" value="../../_tags"/>

--- a/ada_2_fhir/fhir/2_fhir_fhir_include.xsl
+++ b/ada_2_fhir/fhir/2_fhir_fhir_include.xsl
@@ -554,9 +554,15 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
     <xsl:template name="id-to-id" as="element()?">
         <xsl:param name="in" as="element()?"/>
         <xsl:variable name="theID" select="if ($in[@root = $mask-ids-var] | $in[@nullFlavor]) then () else (string-join(($in/@root, $in/@value), '-'))"/>
-        <xsl:if test="matches($theID, '^[A-Za-z\d\.-]{1,64}$')">
-            <id value="{$theID}"/>
-        </xsl:if>
+        <xsl:variable name="theUUID" select="if ($in[@root = $mask-ids-var] | $in[@nullFlavor]) then () else ($in/@value)"/>
+        <xsl:choose>
+            <xsl:when test="matches($theID, '^[A-Za-z\d\.-]{1,64}$')">
+                <id value="{$theID}"/>
+            </xsl:when>
+            <xsl:when test="matches($theUUID, $UUIDpattern)">
+                <id value="{$theUUID}"/>
+            </xsl:when>
+        </xsl:choose>
     </xsl:template>
     <xd:doc>
         <xd:desc>Transforms ada element to FHIR <xd:a href="http://hl7.org/fhir/STU3/datatypes.html#Identifier">Identifier contents</xd:a>. Masks ids, e.g. Burgerservicenummers, if their @root occurs in <xd:ref name="mask-ids" type="parameter"/></xd:desc>
@@ -807,6 +813,11 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                 <xsl:variable name="ii" select="$adaIdentification[matches(@root, $UUIDpattern)][1]"/>
                 <xsl:value-of select="concat('urn:uuid:', $ii/@root)"/>
             </xsl:when>
+            <!-- root = ? and extension = uuid -->
+            <!--<xsl:when test="$adaIdentification[not(@root = $mask-ids-var)][@value][matches(@value, $UUIDpattern)]">
+                <xsl:variable name="ii" select="$adaIdentification[matches(@value, $UUIDpattern)][1]"/>
+                <xsl:value-of select="concat('urn:uuid:', $ii/@value)"/>
+            </xsl:when>-->
             <!-- give up and do new uuid -->
             <xsl:otherwise>
                 <xsl:value-of select="nf:get-fhir-uuid($adaIdentification[1])"/>

--- a/ada_2_fhir/ketenzorg/2_fhir_ketenzorg_include.xsl
+++ b/ada_2_fhir/ketenzorg/2_fhir_ketenzorg_include.xsl
@@ -455,7 +455,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                     </period>
                 </xsl:if>
                 
-                <xsl:for-each select="../bundle/author">
+                <xsl:for-each select="../bundle/author/health_professional">
                     <author>
                         <extension url="{$urlExtNLPractitionerRoleReference}">
                             <valueReference>
@@ -849,6 +849,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                             <xsl:choose>
                                 <xsl:when test="$theEncounters/f:fullUrl[ends-with(@value, $theReference)]">
                                     <reference value="{$theReference}"/>
+                                    <display value="Contact: {nf:get-encounter-display($theEncounters[f:fullUrl[ends-with(@value, $theReference)]]/f:resource/*)}"/>
                                 </xsl:when>
                                 <xsl:otherwise>
                                     <identifier>
@@ -856,9 +857,9 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                                             <xsl:with-param name="in" select="."/>
                                         </xsl:call-template>
                                     </identifier>
+                                    <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                                 </xsl:otherwise>
                             </xsl:choose>
-                            <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                         </context>
                     </xsl:for-each>
                     <!--NL-CM:13.1.9	TestMethod	0..1	The test method used to obtain the result.	246501002 Technique (attribute)	ListTestMethodCodelist-->
@@ -1016,6 +1017,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                         <xsl:choose>
                             <xsl:when test="$theEncounters/f:fullUrl[ends-with(@value, $theReference)]">
                                 <reference value="{$theReference}"/>
+                                <display value="Contact: {nf:get-encounter-display($theEncounters[f:fullUrl[ends-with(@value, $theReference)]]/f:resource/*)}"/>
                             </xsl:when>
                             <xsl:otherwise>
                                 <identifier>
@@ -1023,9 +1025,9 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                                         <xsl:with-param name="in" select="."/>
                                     </xsl:call-template>
                                 </identifier>
+                                <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                             </xsl:otherwise>
                         </xsl:choose>
-                        <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                     </context>
                 </xsl:for-each>
                 <!--NL-CM:13.3.9 			ResultDateTime 	0..1 	Date and if possible the time at which the measurement was carried out.-->
@@ -1210,6 +1212,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                         <xsl:choose>
                             <xsl:when test="$theEncounters/f:fullUrl[ends-with(@value, $theReference)]">
                                 <reference value="{$theReference}"/>
+                                <display value="Contact: {nf:get-encounter-display($theEncounters[f:fullUrl[ends-with(@value, $theReference)]]/f:resource/*)}"/>
                             </xsl:when>
                             <xsl:otherwise>
                                 <identifier>
@@ -1217,12 +1220,12 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                                         <xsl:with-param name="in" select="."/>
                                     </xsl:call-template>
                                 </identifier>
+                                <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                             </xsl:otherwise>
                         </xsl:choose>
-                        <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                     </context>
                 </xsl:for-each>
-                <xsl:for-each select="$author">
+                <xsl:for-each select="$author/health_professional">
                     <performer>
                         <xsl:apply-templates select="." mode="doPractitionerReference-2.0"/>
                     </performer>
@@ -1332,6 +1335,7 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                         <xsl:choose>
                             <xsl:when test="$theEncounters/f:fullUrl[ends-with(@value, $theReference)]">
                                 <reference value="{$theReference}"/>
+                                <display value="Contact: {nf:get-encounter-display($theEncounters[f:fullUrl[ends-with(@value, $theReference)]]/f:resource/*)}"/>
                             </xsl:when>
                             <xsl:otherwise>
                                 <identifier>
@@ -1339,9 +1343,9 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                                         <xsl:with-param name="in" select="."/>
                                     </xsl:call-template>
                                 </identifier>
+                                <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                             </xsl:otherwise>
                         </xsl:choose>
-                        <display value="Contact ID: {string-join((@value, @root), ' ')}"/>
                     </encounter>
                 </xsl:for-each>
                 
@@ -1352,8 +1356,13 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
                         </xsl:call-template>
                     </xsl:attribute>
                 </date>
-                <xsl:for-each select="$author">
+                <xsl:for-each select="$author/health_professional">
                     <author>
+                        <extension url="{$urlExtNLPractitionerRoleReference}">
+                            <valueReference>
+                                <xsl:apply-templates select="." mode="doPractitionerRoleReference-2.0"/>
+                            </valueReference>
+                        </extension>
                         <xsl:apply-templates select="." mode="doPractitionerReference-2.0"/>
                     </author>
                 </xsl:for-each>
@@ -1460,17 +1469,42 @@ The full text of the license is available at http://www.gnu.org/copyleft/lesser.
         <!-- Add resource.text -->
         <xsl:apply-templates select="$resource" mode="addNarrative"/>
     </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>If <xd:ref name="healthProfessional" type="parameter"/> holds a value, return a human readable string of health_professional_identification_number/name_information/organization_name/specialty/health_professional_role. Else return empty</xd:desc>
+        <xd:param name="healthProfessional"/>
+    </xd:doc>
+    <xsl:function name="nf:get-encounter-display" as="xs:string?">
+        <xsl:param name="encounter" as="element()?"/>
+        <xsl:for-each select="$encounter">
+            <xsl:variable name="theType" select="f:type/f:coding/f:display/@value"/>
+            <xsl:variable name="personName" select="f:participant[f:type/f:coding/f:code/@value = 'PRF']/f:individual/f:display/@value"/>
+            <xsl:variable name="theDateString" select="substring(f:period/f:start/@value, 1, 10)"/>
+            <xsl:variable name="theDate" select="if ($theDateString castable as xs:date) then format-date(xs:date($theDateString), '[D01]-[M01]-[Y0001]') else $theDateString"/>
+            <xsl:value-of select="normalize-space(string-join((string-join(($theType, string-join($personName, ' en ')), ' met '), $theDate), ' op '))"/>
+        </xsl:for-each>
+    </xsl:function>
 
     <xd:doc>
         <xd:desc/>
     </xd:doc>
     <xsl:template name="observationEntry" match="journaalregel | journal_entry" mode="doObservationEntry">
         <xsl:variable name="ada-id" select="nf:get-fhir-uuid(.)"/>
+        <xsl:variable name="author" as="element()*">
+            <xsl:choose>
+                <xsl:when test="ancestor::encounter_note[1]/hcimroot/author">
+                    <xsl:copy-of select="ancestor::encounter_note[1]/hcimroot/author"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:copy-of select="ancestor::encounter_note[1]/preceding-sibling::bundle/author"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
         <entry>
             <fullUrl value="{$ada-id}"/>
             <resource>
                 <xsl:call-template name="gp-JournalEntry">
-                    <xsl:with-param name="author" select="../bundle/author"/>
+                    <xsl:with-param name="author" select="$author"/>
                     <xsl:with-param name="subject" select="ancestor::*[bundle]/bundle/subject"/>
                 </xsl:call-template>
             </resource>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/alerts_REPC_IN990121NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/alerts_REPC_IN990121NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.54652+02:00"
-         last-update-date="2023-04-25T15:58:09.54652+02:00"/>
+         creation-date="2023-10-03T20:31:08.780483+02:00"
+         last-update-date="2023-10-03T20:31:08.780483+02:00"/>
    <data>
       <alerts_response app="ketenzorg3.0"
                        shortName="alerts_response"
@@ -16,7 +16,7 @@
                        prefix="kz-"
                        language="en-US"
                        title="Generated Through Conversion"
-                       id="36053297-e371-11ed-1316-020000000000">
+                       id="054fb545-621b-11ee-1908-020000000000">
          <bundle>
             <type code="74018-3"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -67,7 +67,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_POOB_IN990003NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_POOB_IN990003NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.466989+02:00"
-         last-update-date="2023-04-25T15:58:09.466989+02:00"/>
+         creation-date="2023-10-03T20:31:08.699481+02:00"
+         last-update-date="2023-10-03T20:31:08.699481+02:00"/>
    <data>
       <general_measurements_response app="ketenzorg3.0"
                                      shortName="general_measurements_response"
@@ -16,7 +16,7 @@
                                      prefix="kz-"
                                      language="en-US"
                                      title="Generated Through Conversion"
-                                     id="35f8f3c3-e371-11ed-1288-020000000000">
+                                     id="05433cfb-621b-11ee-2324-020000000000">
          <bundle>
             <type code="27899-4"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_bundle_POOB_IN990003NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_bundle_POOB_IN990003NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.475979+02:00"
-         last-update-date="2023-04-25T15:58:09.475979+02:00"/>
+         creation-date="2023-10-03T20:31:08.708795+02:00"
+         last-update-date="2023-10-03T20:31:08.708795+02:00"/>
    <data>
       <general_measurements_response app="ketenzorg3.0"
                                      shortName="general_measurements_response"
@@ -16,7 +16,7 @@
                                      prefix="kz-"
                                      language="en-US"
                                      title="Generated Through Conversion"
-                                     id="35fa5b92-e371-11ed-1934-020000000000">
+                                     id="0544b172-621b-11ee-1373-020000000000">
          <bundle>
             <type code="27899-4"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_EX990131NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_EX990131NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.826552+02:00"
-         last-update-date="2023-04-25T15:58:08.826552+02:00"/>
+         creation-date="2023-10-03T20:31:08.057887+02:00"
+         last-update-date="2023-10-03T20:31:08.057887+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="35973a9b-e371-11ed-1040-020000000000">
+                                    id="04e156a1-621b-11ee-1044-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_IN990131NL_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_IN990131NL_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.842053+02:00"
-         last-update-date="2023-04-25T15:58:08.842053+02:00"/>
+         creation-date="2023-10-03T20:31:08.075842+02:00"
+         last-update-date="2023-10-03T20:31:08.075842+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="3599b070-e371-11ed-1691-020000000000">
+                                    id="04e42c52-621b-11ee-1588-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -78,7 +78,7 @@
                         <house_number value="15"/>
                         <postcode value="4812 XA"/>
                         <place_of_residence value="Breda"/>
-                        <country value="Nederland"/>
+                        <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                         <address_type code="WP"
                                       codeSystem="2.16.840.1.113883.5.1119"
                                       displayName="Work Place"/>
@@ -133,7 +133,7 @@
                         <house_number value="15"/>
                         <postcode value="4812 XA"/>
                         <place_of_residence value="Breda"/>
-                        <country value="Nederland"/>
+                        <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                         <address_type code="WP"
                                       codeSystem="2.16.840.1.113883.5.1119"
                                       displayName="Work Place"/>
@@ -188,7 +188,7 @@
                         <house_number value="15"/>
                         <postcode value="4812 XA"/>
                         <place_of_residence value="Breda"/>
-                        <country value="Nederland"/>
+                        <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                         <address_type code="WP"
                                       codeSystem="2.16.840.1.113883.5.1119"
                                       displayName="Work Place"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.8592+02:00"
-         last-update-date="2023-04-25T15:58:08.8592+02:00"/>
+         creation-date="2023-10-03T20:31:08.092185+02:00"
+         last-update-date="2023-10-03T20:31:08.092185+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="359c42e2-e371-11ed-9796-020000000000">
+                                    id="04e69f5c-621b-11ee-1315-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -91,7 +91,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="359c438c-e371-11ed-9796-020000000000">
+                                    id="04e6a006-621b-11ee-1315-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.867775+02:00"
-         last-update-date="2023-04-25T15:58:08.867775+02:00"/>
+         creation-date="2023-10-03T20:31:08.101566+02:00"
+         last-update-date="2023-10-03T20:31:08.101566+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="359da142-e371-11ed-5385-020000000000">
+                                    id="04e81d38-621b-11ee-5176-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.628814+02:00"
-         last-update-date="2023-04-25T15:58:09.628814+02:00"/>
+         creation-date="2023-10-03T20:31:08.86284+02:00"
+         last-update-date="2023-10-03T20:31:08.86284+02:00"/>
    <data>
       <encounters_response app="ketenzorg3.0"
                            shortName="encounters_response"
@@ -16,7 +16,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="3611a50d-e371-11ed-1057-020000000000">
+                           id="055c2a31-621b-11ee-1544-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_02_HACONTMOM.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_02_HACONTMOM.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.632313+02:00"
-         last-update-date="2023-04-25T15:58:09.632313+02:00"/>
+         creation-date="2023-10-03T20:31:08.865887+02:00"
+         last-update-date="2023-10-03T20:31:08.865887+02:00"/>
    <data>
       <encounters_response app="ketenzorg3.0"
                            shortName="encounters_response"
@@ -16,7 +16,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="3612421a-e371-11ed-6699-020000000000">
+                           id="055cb596-621b-11ee-1562-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.094922+02:00"
-         last-update-date="2023-04-25T15:58:09.094922+02:00"/>
+         creation-date="2023-10-03T20:31:08.33276+02:00"
+         last-update-date="2023-10-03T20:31:08.33276+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c02de5-e371-11ed-2519-020000000000">
+                                id="050b47f1-621b-11ee-2715-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.105445+02:00"
-         last-update-date="2023-04-25T15:58:09.105445+02:00"/>
+         creation-date="2023-10-03T20:31:08.341744+02:00"
+         last-update-date="2023-10-03T20:31:08.341744+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c1dc61-e371-11ed-8716-020000000000">
+                                id="050cba4f-621b-11ee-7631-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_03.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_03.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.133408+02:00"
-         last-update-date="2023-04-25T15:58:09.133408+02:00"/>
+         creation-date="2023-10-03T20:31:08.364587+02:00"
+         last-update-date="2023-10-03T20:31:08.364587+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c61239-e371-11ed-2104-020000000000">
+                                id="05102827-621b-11ee-1112-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_01_met_contacten.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_01_met_contacten.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.151987+02:00"
-         last-update-date="2023-04-25T15:58:09.151987+02:00"/>
+         creation-date="2023-10-03T20:31:08.382636+02:00"
+         last-update-date="2023-10-03T20:31:08.382636+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c8ef8e-e371-11ed-1862-020000000000">
+                                id="0512f0c8-621b-11ee-7464-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>
@@ -83,7 +83,8 @@
                </author>
                <date_time value="2019-01-30T16:45:00"/>
             </hcimroot>
-            <encounter value="996625" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+            <encounter value="d8db035c-6214-11ee-5414-020000000000"
+                       root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             <episode value="1826" root="2.16.840.1.113883.2.4.6.6.90000258.4.6"/>
             <journal_entry>
                <type value="1"
@@ -241,7 +242,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="35c8f131-e371-11ed-1862-020000000000">
+                           id="0512f26b-621b-11ee-7464-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -272,7 +273,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>
@@ -285,7 +286,8 @@
          </bundle>
          <encounter>
             <hcimroot>
-               <identification_number value="996625" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <identification_number value="d8db035c-6214-11ee-5414-020000000000"
+                                      root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </hcimroot>
             <contact_type code="03"
                           codeSystem="2.16.840.1.113883.2.4.4.30.14"

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_02_met_contacten.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_02_met_contacten.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.160854+02:00"
-         last-update-date="2023-04-25T15:58:09.160854+02:00"/>
+         creation-date="2023-10-03T20:31:08.392819+02:00"
+         last-update-date="2023-10-03T20:31:08.392819+02:00"/>
    <data>
       <encounters_response app="ketenzorg3.0"
                            shortName="encounters_response"
@@ -16,7 +16,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="35ca5d70-e371-11ed-6278-020000000000">
+                           id="05149212-621b-11ee-9563-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_03_met_contacten.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_03_met_contacten.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.173146+02:00"
-         last-update-date="2023-04-25T15:58:09.173146+02:00"/>
+         creation-date="2023-10-03T20:31:08.405359+02:00"
+         last-update-date="2023-10-03T20:31:08.405359+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35cc1ee9-e371-11ed-1921-020000000000">
+                                id="05165d3b-621b-11ee-1396-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>
@@ -1110,7 +1110,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="35cc2628-e371-11ed-1921-020000000000">
+                           id="0516647a-621b-11ee-1396-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -1141,7 +1141,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/diagnostische_bepalingen_bundle_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/diagnostische_bepalingen_bundle_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.293424+02:00"
-         last-update-date="2023-04-25T15:58:09.293424+02:00"/>
+         creation-date="2023-10-03T20:31:08.525502+02:00"
+         last-update-date="2023-10-03T20:31:08.525502+02:00"/>
    <data>
       <lab_results_response app="ketenzorg3.0"
                             shortName="lab_results_response"
@@ -16,7 +16,7 @@
                             prefix="kz-"
                             language="en-US"
                             title="Generated Through Conversion"
-                            id="35de78bb-e371-11ed-1875-020000000000">
+                            id="0528b1c7-621b-11ee-1863-020000000000">
          <bundle>
             <type code="26436-6"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>
@@ -210,7 +210,7 @@
                                      prefix="kz-"
                                      language="en-US"
                                      title="Generated Through Conversion"
-                                     id="35de9411-e371-11ed-1875-020000000000">
+                                     id="0528cd1d-621b-11ee-1863-020000000000">
          <bundle>
             <type code="27899-4"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -241,7 +241,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.986492+02:00"
-         last-update-date="2023-04-25T15:58:08.986492+02:00"/>
+         creation-date="2023-10-03T20:31:08.223927+02:00"
+         last-update-date="2023-10-03T20:31:08.223927+02:00"/>
    <data>
       <episodes_response app="ketenzorg3.0"
                          shortName="episodes_response"
@@ -16,7 +16,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35afa241-e371-11ed-3518-020000000000">
+                         id="04faac8f-621b-11ee-1241-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.991311+02:00"
-         last-update-date="2023-04-25T15:58:08.991311+02:00"/>
+         creation-date="2023-10-03T20:31:08.2284+02:00"
+         last-update-date="2023-10-03T20:31:08.2284+02:00"/>
    <data>
       <episodes_response app="ketenzorg3.0"
                          shortName="episodes_response"
@@ -16,7 +16,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35b0673e-e371-11ed-1673-020000000000">
+                         id="04fb6408-621b-11ee-1720-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_bundle_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_bundle_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.995434+02:00"
-         last-update-date="2023-04-25T15:58:08.995434+02:00"/>
+         creation-date="2023-10-03T20:31:08.23238+02:00"
+         last-update-date="2023-10-03T20:31:08.23238+02:00"/>
    <data>
       <episodes_response app="ketenzorg3.0"
                          shortName="episodes_response"
@@ -16,7 +16,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35b100d3-e371-11ed-1497-020000000000">
+                         id="04fbf807-621b-11ee-5319-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -102,7 +102,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35b1016a-e371-11ed-1497-020000000000">
+                         id="04fbf89e-621b-11ee-5319-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/labbepalingen_POLB_IN364001NL03_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/labbepalingen_POLB_IN364001NL03_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.38439+02:00"
-         last-update-date="2023-04-25T15:58:09.38439+02:00"/>
+         creation-date="2023-10-03T20:31:08.621355+02:00"
+         last-update-date="2023-10-03T20:31:08.621355+02:00"/>
    <data>
       <lab_results_response app="ketenzorg3.0"
                             shortName="lab_results_response"
@@ -16,7 +16,7 @@
                             prefix="kz-"
                             language="en-US"
                             title="Generated Through Conversion"
-                            id="35ec593d-e371-11ed-5715-020000000000">
+                            id="0537512f-621b-11ee-7697-020000000000">
          <bundle>
             <type code="26436-6"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_Kwalificatie.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_Kwalificatie.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.907535+02:00"
-         last-update-date="2023-04-25T15:58:09.907535+02:00"/>
+         creation-date="2023-10-03T20:31:09.192271+02:00"
+         last-update-date="2023-10-03T20:31:09.192271+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363c2f74-e371-11ed-1687-020000000000">
+                                             id="058e7174-621b-11ee-2122-020000000000">
          <patient>
             <naamgegevens>
                <initialen value="E."/>
@@ -33,7 +33,7 @@
                <huisnummer value="1001"/>
                <postcode value="9999 XX"/>
                <woonplaats value="STITSWERD"/>
-               <land value="Nederland"/>
+               <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                <adres_soort code="HP"
                             codeSystem="2.16.840.1.113883.5.1119"
                             displayName="Primary Home"/>
@@ -88,7 +88,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -178,7 +178,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -278,7 +278,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -370,7 +370,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -459,7 +459,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -556,7 +556,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -646,7 +646,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_01.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.915954+02:00"
-         last-update-date="2023-04-25T15:58:09.915954+02:00"/>
+         creation-date="2023-10-03T20:31:09.200749+02:00"
+         last-update-date="2023-10-03T20:31:09.200749+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363d8bdd-e371-11ed-1699-020000000000">
+                                             id="058fd02b-621b-11ee-9007-020000000000">
          <patient>
             <naamgegevens>
                <voornamen value="Joris"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_02.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.91819+02:00"
-         last-update-date="2023-04-25T15:58:09.91819+02:00"/>
+         creation-date="2023-10-03T20:31:09.202858+02:00"
+         last-update-date="2023-10-03T20:31:09.202858+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363de537-e371-11ed-1957-020000000000">
+                                             id="0590248f-621b-11ee-9712-020000000000">
          <patient>
             <naamgegevens>
                <initialen value="H."/>
@@ -33,7 +33,7 @@
                <huisnummer value="1003"/>
                <postcode value="9999 ZA"/>
                <woonplaats value="STITSWERD"/>
-               <land value="Nederland"/>
+               <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
             </adresgegevens>
             <identificatienummer value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
             <geboortedatum value="1985-12-30"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_XXX_Amaya-907.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_XXX_Amaya-907.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.920431+02:00"
-         last-update-date="2023-04-25T15:58:09.920431+02:00"/>
+         creation-date="2023-10-03T20:31:09.204816+02:00"
+         last-update-date="2023-10-03T20:31:09.204816+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363e23f8-e371-11ed-1019-020000000000">
+                                             id="05905842-621b-11ee-1997-020000000000">
          <patient>
             <naamgegevens>
                <initialen value="J."/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/alerts_REPC_IN990121NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/alerts_REPC_IN990121NL_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="37bd028a-e371-11ed-9239-020000000000"/>
+   <id value="07114da2-621b-11ee-5889-020000000000"/>
    <type value="searchset"/>
    <total value="4"/>
    <link>
@@ -58,7 +58,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37bd1217-e371-11ed-9239-020000000000"/>
+               <reference value="urn:uuid:07115d2f-621b-11ee-5889-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
          </Flag>
@@ -117,7 +117,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37bd1217-e371-11ed-9239-020000000000"/>
+               <reference value="urn:uuid:07115d2f-621b-11ee-5889-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
          </Flag>
@@ -189,7 +189,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37bd1217-e371-11ed-9239-020000000000"/>
+               <reference value="urn:uuid:07115d2f-621b-11ee-5889-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <period>
@@ -251,7 +251,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37bd1217-e371-11ed-9239-020000000000"/>
+               <reference value="urn:uuid:07115d2f-621b-11ee-5889-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
          </Flag>
@@ -261,7 +261,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37bd1217-e371-11ed-9239-020000000000"/>
+      <fullUrl value="urn:uuid:07115d2f-621b-11ee-5889-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -271,7 +271,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -337,7 +337,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/algemene_bepalingen_POOB_IN990003NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/algemene_bepalingen_POOB_IN990003NL_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="37934648-e371-11ed-1214-020000000000"/>
+   <id value="06e8609a-621b-11ee-1152-020000000000"/>
    <type value="searchset"/>
    <total value="24"/>
    <link>
@@ -82,7 +82,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -96,7 +96,7 @@
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -198,14 +198,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -307,14 +307,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -410,14 +410,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -484,14 +484,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -561,14 +561,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -666,14 +666,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -761,14 +761,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -835,14 +835,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -908,14 +908,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -986,14 +986,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1088,14 +1088,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1188,14 +1188,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1258,14 +1258,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1332,14 +1332,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1407,14 +1407,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1486,14 +1486,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-03"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1588,14 +1588,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1693,14 +1693,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1791,14 +1791,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1887,14 +1887,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1961,14 +1961,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2036,14 +2036,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2112,14 +2112,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+               <reference value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+                     <reference value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2140,7 +2140,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:379355cc-e371-11ed-1214-020000000000"/>
+      <fullUrl value="urn:uuid:06e8701e-621b-11ee-1152-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -2150,7 +2150,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -2216,7 +2216,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -2282,7 +2292,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:379355e3-e371-11ed-1214-020000000000"/>
+      <fullUrl value="urn:uuid:06e87035-621b-11ee-1152-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/algemene_bepalingen_bundle_POOB_IN990003NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/algemene_bepalingen_bundle_POOB_IN990003NL_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="3797c0f6-e371-11ed-2132-020000000000"/>
+   <id value="06ec8ab2-621b-11ee-6432-020000000000"/>
    <type value="searchset"/>
    <total value="19"/>
    <link>
@@ -72,7 +72,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -159,7 +159,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -241,7 +241,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -328,7 +328,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -415,7 +415,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -488,7 +488,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -561,7 +561,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -634,7 +634,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -707,7 +707,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -780,7 +780,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -853,7 +853,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -940,7 +940,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -1027,7 +1027,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -1114,7 +1114,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -1203,7 +1203,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -1291,7 +1291,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
@@ -1356,14 +1356,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <effectiveDateTime value="2020-10-21"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3797c543-e371-11ed-2132-020000000000"/>
+                     <reference value="urn:uuid:06ec8eff-621b-11ee-6432-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1424,14 +1424,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <effectiveDateTime value="2020-10-21"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3797c543-e371-11ed-2132-020000000000"/>
+                     <reference value="urn:uuid:06ec8eff-621b-11ee-6432-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1497,14 +1497,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+               <reference value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <effectiveDateTime value="2020-10-21"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3797c543-e371-11ed-2132-020000000000"/>
+                     <reference value="urn:uuid:06ec8eff-621b-11ee-6432-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1544,7 +1544,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3797ac08-e371-11ed-2132-020000000000"/>
+      <fullUrl value="urn:uuid:06ec75c4-621b-11ee-6432-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -1554,7 +1554,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">J. XXX_Cevat</span>, Man, 30 december 1985</div>
-                  <div>Knolweg 1003, 9999ZA STITSWERD, Nederland</div>
+                  <div>Knolweg 1003, 9999ZA STITSWERD, NL</div>
                </div>
             </text>
             <identifier>
@@ -1603,7 +1603,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999ZA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -1669,7 +1679,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3797c543-e371-11ed-2132-020000000000"/>
+      <fullUrl value="urn:uuid:06ec8eff-621b-11ee-6432-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_REPC_EX990131NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_REPC_EX990131NL_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="369654ba-e371-11ed-1523-020000000000"/>
+   <id value="05e58a6a-621b-11ee-1358-020000000000"/>
    <type value="searchset"/>
    <total value="1"/>
    <link>
@@ -9,7 +9,7 @@
       <url value="http://dummy.nictiz.nl/dummyquery"/>
    </link>
    <entry>
-      <fullUrl value="urn:uuid:66935281-de15-4033-9be4-a4127812dd95"/>
+      <fullUrl value="https://example.org/fhir/AllergyIntolerance/66935281-de15-4033-9be4-a4127812dd95"/>
       <resource>
          <AllergyIntolerance>
             <meta>
@@ -72,7 +72,7 @@
                <text value="Amoxicilline"/>
             </code>
             <patient>
-               <reference value="urn:uuid:3696643f-e371-11ed-1523-020000000000"/>
+               <reference value="urn:uuid:05e599ef-621b-11ee-1358-020000000000"/>
                <display value="Joris Hansman"/>
             </patient>
             <onsetDateTime value="2015-03-04"/>
@@ -86,7 +86,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3696643f-e371-11ed-1523-020000000000"/>
+      <fullUrl value="urn:uuid:05e599ef-621b-11ee-1358-020000000000"/>
       <resource>
          <Patient>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_REPC_IN990131NL_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_REPC_IN990131NL_02.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="3699d9fa-e371-11ed-1191-020000000000"/>
+   <id value="05e90654-621b-11ee-5430-020000000000"/>
    <type value="searchset"/>
    <total value="3"/>
    <link>
@@ -19,7 +19,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Allergie/intolerantie. Patiënt: Victoria Ketenzorg-Acceptatie. Id: 0000029204000000573 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.90000381.90000012.17), Categorie: <span title="neiging tot ongewenste reactie op geneesmiddel (419511003 - SNOMED CT)">neiging tot ongewenste reactie op geneesmiddel</span>, Status: actief / bevestigd</caption>
+                     <caption>Allergie/intolerantie. Patiënt: Victoria Ketenzorg-Acceptatie. Id: 0000029204000000573 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.90000381.90000012.17), Categorie: <span title="neiging tot ongewenste reactie op medicatie en/of drug (419511003 - SNOMED CT)">neiging tot ongewenste reactie op medicatie en/of drug</span>, Status: actief / bevestigd</caption>
                      <tbody>
                         <tr>
                            <th>Code</th>
@@ -57,7 +57,7 @@
                      <coding>
                         <system value="http://snomed.info/sct"/>
                         <code value="419511003"/>
-                        <display value="neiging tot ongewenste reactie op geneesmiddel"/>
+                        <display value="neiging tot ongewenste reactie op medicatie en/of drug"/>
                      </coding>
                   </valueCodeableConcept>
                </extension>
@@ -70,7 +70,7 @@
                </coding>
             </code>
             <patient>
-               <reference value="urn:uuid:3699f6d0-e371-11ed-1191-020000000000"/>
+               <reference value="urn:uuid:05e92384-621b-11ee-5430-020000000000"/>
                <display value="Victoria Ketenzorg-Acceptatie"/>
             </patient>
             <onsetDateTime value="2017-08-20"/>
@@ -91,7 +91,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Allergie/intolerantie. Patiënt: Victoria Ketenzorg-Acceptatie. Id: 0000029207000000073 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.90000381.90000012.9), Categorie: <span title="neiging tot ongewenste reactie op geneesmiddel (419511003 - SNOMED CT)">neiging tot ongewenste reactie op geneesmiddel</span>, Status: actief / bevestigd</caption>
+                     <caption>Allergie/intolerantie. Patiënt: Victoria Ketenzorg-Acceptatie. Id: 0000029207000000073 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.90000381.90000012.9), Categorie: <span title="neiging tot ongewenste reactie op medicatie en/of drug (419511003 - SNOMED CT)">neiging tot ongewenste reactie op medicatie en/of drug</span>, Status: actief / bevestigd</caption>
                      <tbody>
                         <tr>
                            <th>Code</th>
@@ -129,7 +129,7 @@
                      <coding>
                         <system value="http://snomed.info/sct"/>
                         <code value="419511003"/>
-                        <display value="neiging tot ongewenste reactie op geneesmiddel"/>
+                        <display value="neiging tot ongewenste reactie op medicatie en/of drug"/>
                      </coding>
                   </valueCodeableConcept>
                </extension>
@@ -142,7 +142,7 @@
                </coding>
             </code>
             <patient>
-               <reference value="urn:uuid:3699f6d0-e371-11ed-1191-020000000000"/>
+               <reference value="urn:uuid:05e92384-621b-11ee-5430-020000000000"/>
                <display value="Victoria Ketenzorg-Acceptatie"/>
             </patient>
             <onsetDateTime value="2006-05-01"/>
@@ -163,7 +163,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Allergie/intolerantie. Patiënt: Victoria Ketenzorg-Acceptatie. Id: 0000029209000080522 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.90000381.90000012.17), Categorie: <span title="neiging tot ongewenste reactie op geneesmiddel (419511003 - SNOMED CT)">neiging tot ongewenste reactie op geneesmiddel</span>, Status: actief / bevestigd</caption>
+                     <caption>Allergie/intolerantie. Patiënt: Victoria Ketenzorg-Acceptatie. Id: 0000029209000080522 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.90000381.90000012.17), Categorie: <span title="neiging tot ongewenste reactie op medicatie en/of drug (419511003 - SNOMED CT)">neiging tot ongewenste reactie op medicatie en/of drug</span>, Status: actief / bevestigd</caption>
                      <tbody>
                         <tr>
                            <th>Code</th>
@@ -201,7 +201,7 @@
                      <coding>
                         <system value="http://snomed.info/sct"/>
                         <code value="419511003"/>
-                        <display value="neiging tot ongewenste reactie op geneesmiddel"/>
+                        <display value="neiging tot ongewenste reactie op medicatie en/of drug"/>
                      </coding>
                   </valueCodeableConcept>
                </extension>
@@ -214,7 +214,7 @@
                </coding>
             </code>
             <patient>
-               <reference value="urn:uuid:3699f6d0-e371-11ed-1191-020000000000"/>
+               <reference value="urn:uuid:05e92384-621b-11ee-5430-020000000000"/>
                <display value="Victoria Ketenzorg-Acceptatie"/>
             </patient>
             <onsetDateTime value="2021-04-30"/>
@@ -225,7 +225,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3699f6d0-e371-11ed-1191-020000000000"/>
+      <fullUrl value="urn:uuid:05e92384-621b-11ee-5430-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -320,7 +320,10 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 900021032 (UZI-NR-PERS), Waarnemend Huisarts 2</div>
-                  <div>Ettensebaan 15, 4812XA Breda, Nederland (WP)</div>
+                  <div>
+                     <a href="tel:+31434074766">+31434074766</a> (Tel)</div>
+                  <div>Ettensebaan 15, 4812XA Breda, NL (WP)<br/>Maastricht<br/>
+                  </div>
                </div>
             </text>
             <identifier>
@@ -330,6 +333,10 @@
             <name>
                <text value="Waarnemend Huisarts 2"/>
             </name>
+            <telecom>
+               <system value="phone"/>
+               <value value="+31434074766"/>
+            </telecom>
             <address>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation-AddressType">
                   <valueCodeableConcept>
@@ -351,7 +358,20 @@
                </line>
                <city value="Breda"/>
                <postalCode value="4812XA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
+            </address>
+            <address>
+               <city value="Maastricht"/>
             </address>
          </Practitioner>
       </resource>
@@ -393,7 +413,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3699f6f5-e371-11ed-1191-020000000000"/>
+      <fullUrl value="urn:uuid:05e923a9-621b-11ee-5430-020000000000"/>
       <resource>
          <Organization>
             <meta>
@@ -432,7 +452,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3699f6e3-e371-11ed-1191-020000000000"/>
+      <fullUrl value="urn:uuid:05e92397-621b-11ee-5430-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -473,7 +493,7 @@
                <display value="Waarnemend Huisarts 2"/>
             </practitioner>
             <organization>
-               <reference value="urn:uuid:3699f6f5-e371-11ed-1191-020000000000"/>
+               <reference value="urn:uuid:05e923a9-621b-11ee-5430-020000000000"/>
                <display value="CGM praktijk op ststect6"/>
             </organization>
             <specialty>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_bundle_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_bundle_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="369bfa46-e371-11ed-2126-020000000000"/>
+   <id value="05eb3c3a-621b-11ee-7891-020000000000"/>
    <type value="searchset"/>
    <total value="4"/>
    <link>
@@ -9,7 +9,7 @@
       <url value="http://dummy.nictiz.nl/dummyquery"/>
    </link>
    <entry>
-      <fullUrl value="urn:uuid:66935281-de15-4033-9be4-a4127812dd95"/>
+      <fullUrl value="https://example.org/fhir/AllergyIntolerance/66935281-de15-4033-9be4-a4127812dd95"/>
       <resource>
          <AllergyIntolerance>
             <meta>
@@ -67,7 +67,7 @@
                <text value="Amoxicilline, opmerking: via neuroloog"/>
             </code>
             <patient>
-               <reference value="urn:uuid:369bfd9a-e371-11ed-2126-020000000000"/>
+               <reference value="urn:uuid:05eb436c-621b-11ee-7891-020000000000"/>
                <display value="L XXX_Charan"/>
             </patient>
             <onsetDateTime value="2018-11-20T11:58:34+01:00"/>
@@ -78,7 +78,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:66935281-de15-4033-9be4-a4127812dd95"/>
+      <fullUrl value="https://example.org/fhir/AllergyIntolerance/66935281-de15-4033-9be4-a4127812dd95"/>
       <resource>
          <AllergyIntolerance>
             <meta>
@@ -136,7 +136,7 @@
                <text value="Amoxicilline, opmerking: via neuroloog"/>
             </code>
             <patient>
-               <reference value="urn:uuid:369bfd9a-e371-11ed-2126-020000000000"/>
+               <reference value="urn:uuid:05eb436c-621b-11ee-7891-020000000000"/>
                <display value="L XXX_Charan"/>
             </patient>
             <onsetDateTime value="2018-11-20T11:58:34+01:00"/>
@@ -147,7 +147,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:66935281-de15-4033-9be4-a4127812dd95"/>
+      <fullUrl value="https://example.org/fhir/AllergyIntolerance/66935281-de15-4033-9be4-a4127812dd95"/>
       <resource>
          <AllergyIntolerance>
             <meta>
@@ -205,7 +205,7 @@
                <text value="Amoxicilline, opmerking: via neuroloog"/>
             </code>
             <patient>
-               <reference value="urn:uuid:369bfd9a-e371-11ed-2126-020000000000"/>
+               <reference value="urn:uuid:05eb436c-621b-11ee-7891-020000000000"/>
                <display value="L XXX_Charan"/>
             </patient>
             <onsetDateTime value="2018-11-20T11:58:34+01:00"/>
@@ -216,7 +216,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:66935281-de15-4033-9be4-a4127812dd95"/>
+      <fullUrl value="https://example.org/fhir/AllergyIntolerance/66935281-de15-4033-9be4-a4127812dd95"/>
       <resource>
          <AllergyIntolerance>
             <meta>
@@ -274,7 +274,7 @@
                <text value="Amoxicilline, opmerking: via neuroloog"/>
             </code>
             <patient>
-               <reference value="urn:uuid:369bfd9a-e371-11ed-2126-020000000000"/>
+               <reference value="urn:uuid:05eb436c-621b-11ee-7891-020000000000"/>
                <display value="L XXX_Charan"/>
             </patient>
             <onsetDateTime value="2018-11-20T11:58:34+01:00"/>
@@ -285,7 +285,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:369bfd9a-e371-11ed-2126-020000000000"/>
+      <fullUrl value="urn:uuid:05eb436c-621b-11ee-7891-020000000000"/>
       <resource>
          <Patient>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_bundle_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/allergieintoleranties_bundle_02.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="369d934c-e371-11ed-1347-020000000000"/>
+   <id value="05ec93c8-621b-11ee-2071-020000000000"/>
    <type value="searchset"/>
    <total value="2"/>
    <link>
@@ -19,7 +19,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Allergie/intolerantie. Patiënt: van Anoniempje. Id: 3306010885055 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.51732.10003466.17), Categorie: <span title="neiging tot ongewenste reactie op geneesmiddel (419511003 - SNOMED CT)">neiging tot ongewenste reactie op geneesmiddel</span>, Status: actief / bevestigd</caption>
+                     <caption>Allergie/intolerantie. Patiënt: van Anoniempje. Id: 3306010885055 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.51732.10003466.17), Categorie: <span title="neiging tot ongewenste reactie op medicatie en/of drug (419511003 - SNOMED CT)">neiging tot ongewenste reactie op medicatie en/of drug</span>, Status: actief / bevestigd</caption>
                      <tbody>
                         <tr>
                            <th>Code</th>
@@ -57,7 +57,7 @@
                      <coding>
                         <system value="http://snomed.info/sct"/>
                         <code value="419511003"/>
-                        <display value="neiging tot ongewenste reactie op geneesmiddel"/>
+                        <display value="neiging tot ongewenste reactie op medicatie en/of drug"/>
                      </coding>
                   </valueCodeableConcept>
                </extension>
@@ -70,7 +70,7 @@
                </coding>
             </code>
             <patient>
-               <reference value="urn:uuid:369d805c-e371-11ed-1347-020000000000"/>
+               <reference value="urn:uuid:05ec861e-621b-11ee-2071-020000000000"/>
                <display value="van Anoniempje"/>
             </patient>
             <onsetDateTime value="2011-08-16"/>
@@ -91,7 +91,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Allergie/intolerantie. Patiënt: van Anoniempje. Id: 0000593307014888565 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.51732.10003466.17), Categorie: <span title="neiging tot ongewenste reactie op geneesmiddel (419511003 - SNOMED CT)">neiging tot ongewenste reactie op geneesmiddel</span>, Status: actief / bevestigd</caption>
+                     <caption>Allergie/intolerantie. Patiënt: van Anoniempje. Id: 0000593307014888565 (urn:oid:2.16.840.1.113883.2.4.3.39.6101.51732.10003466.17), Categorie: <span title="neiging tot ongewenste reactie op medicatie en/of drug (419511003 - SNOMED CT)">neiging tot ongewenste reactie op medicatie en/of drug</span>, Status: actief / bevestigd</caption>
                      <tbody>
                         <tr>
                            <th>Code</th>
@@ -129,7 +129,7 @@
                      <coding>
                         <system value="http://snomed.info/sct"/>
                         <code value="419511003"/>
-                        <display value="neiging tot ongewenste reactie op geneesmiddel"/>
+                        <display value="neiging tot ongewenste reactie op medicatie en/of drug"/>
                      </coding>
                   </valueCodeableConcept>
                </extension>
@@ -142,7 +142,7 @@
                </coding>
             </code>
             <patient>
-               <reference value="urn:uuid:369d805c-e371-11ed-1347-020000000000"/>
+               <reference value="urn:uuid:05ec861e-621b-11ee-2071-020000000000"/>
                <display value="van Anoniempje"/>
             </patient>
             <onsetDateTime value="2011-08-16"/>
@@ -153,7 +153,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:369d805c-e371-11ed-1347-020000000000"/>
+      <fullUrl value="urn:uuid:05ec861e-621b-11ee-2071-020000000000"/>
       <resource>
          <Patient>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactmomenten_PRPA_IN900350NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactmomenten_PRPA_IN900350NL_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="37dfb668-e371-11ed-1401-020000000000"/>
+   <id value="07346058-621b-11ee-1962-020000000000"/>
    <type value="searchset"/>
    <total value="2"/>
    <link>
@@ -79,7 +79,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37dfc5ec-e371-11ed-1401-020000000000"/>
+               <reference value="urn:uuid:07346fdc-621b-11ee-1962-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <episodeOfCare>
@@ -100,7 +100,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37dfc601-e371-11ed-1401-020000000000"/>
+                        <reference value="urn:uuid:07346ff1-621b-11ee-1962-020000000000"/>
                         <display value="XIS test || Huisarts || Tést Zorginstelling 02"/>
                      </valueReference>
                   </extension>
@@ -113,7 +113,7 @@
                <end value="2019-02-03T16:51:00+01:00"/>
             </period>
             <serviceProvider>
-               <reference value="urn:uuid:37dfc608-e371-11ed-1401-020000000000"/>
+               <reference value="urn:uuid:07346ff8-621b-11ee-1962-020000000000"/>
                <display value="Tést Zorginstelling 02"/>
             </serviceProvider>
          </Encounter>
@@ -193,7 +193,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37dfc5ec-e371-11ed-1401-020000000000"/>
+               <reference value="urn:uuid:07346fdc-621b-11ee-1962-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <episodeOfCare>
@@ -214,7 +214,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37dfc601-e371-11ed-1401-020000000000"/>
+                        <reference value="urn:uuid:07346ff1-621b-11ee-1962-020000000000"/>
                         <display value="XIS test || Huisarts || Tést Zorginstelling 02"/>
                      </valueReference>
                   </extension>
@@ -227,7 +227,7 @@
                <end value="2019-02-06T17:08:00+01:00"/>
             </period>
             <serviceProvider>
-               <reference value="urn:uuid:37dfc608-e371-11ed-1401-020000000000"/>
+               <reference value="urn:uuid:07346ff8-621b-11ee-1962-020000000000"/>
                <display value="Tést Zorginstelling 02"/>
             </serviceProvider>
          </Encounter>
@@ -237,7 +237,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37dfc5ec-e371-11ed-1401-020000000000"/>
+      <fullUrl value="urn:uuid:07346fdc-621b-11ee-1962-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -247,7 +247,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -313,7 +313,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -390,7 +400,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37dfc608-e371-11ed-1401-020000000000"/>
+      <fullUrl value="urn:uuid:07346ff8-621b-11ee-1962-020000000000"/>
       <resource>
          <Organization>
             <meta>
@@ -422,7 +432,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37dfc601-e371-11ed-1401-020000000000"/>
+      <fullUrl value="urn:uuid:07346ff1-621b-11ee-1962-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -458,7 +468,7 @@
                <display value="XIS test"/>
             </practitioner>
             <organization>
-               <reference value="urn:uuid:37dfc608-e371-11ed-1401-020000000000"/>
+               <reference value="urn:uuid:07346ff8-621b-11ee-1962-020000000000"/>
                <display value="Tést Zorginstelling 02"/>
             </organization>
             <specialty>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactmomenten_PRPA_IN900350NL_02_HACONTMOM.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactmomenten_PRPA_IN900350NL_02_HACONTMOM.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="37e19118-e371-11ed-1664-020000000000"/>
+   <id value="07362f8c-621b-11ee-2027-020000000000"/>
    <type value="searchset"/>
    <total value="19"/>
    <link>
@@ -81,7 +81,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -102,7 +102,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -197,7 +197,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -218,7 +218,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -313,7 +313,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -334,7 +334,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -429,7 +429,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -450,7 +450,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -545,7 +545,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -566,7 +566,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -661,7 +661,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -682,7 +682,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -777,7 +777,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -798,7 +798,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -893,7 +893,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -914,7 +914,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1009,7 +1009,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -1030,7 +1030,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1125,7 +1125,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -1146,7 +1146,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1241,7 +1241,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -1262,7 +1262,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1357,7 +1357,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -1378,7 +1378,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1473,7 +1473,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -1494,7 +1494,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1589,7 +1589,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -1610,7 +1610,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1705,7 +1705,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -1726,7 +1726,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1821,7 +1821,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <participant>
@@ -1835,7 +1835,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -1930,7 +1930,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <participant>
@@ -1944,7 +1944,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2039,7 +2039,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2060,7 +2060,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2083,7 +2083,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37e195e1-e371-11ed-1664-020000000000"/>
+      <fullUrl value="urn:uuid:07363455-621b-11ee-2027-020000000000"/>
       <resource>
          <Encounter>
             <meta>
@@ -2152,7 +2152,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+               <reference value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2173,7 +2173,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+                        <reference value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2196,7 +2196,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37e1833c-e371-11ed-1664-020000000000"/>
+      <fullUrl value="urn:uuid:073621b0-621b-11ee-2027-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -2206,7 +2206,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">J. XXX_Cevat</span>, Man, 30 december 1985</div>
-                  <div>Knolweg 1003, 9999ZA STITSWERD, Nederland</div>
+                  <div>Knolweg 1003, 9999ZA STITSWERD, NL</div>
                </div>
             </text>
             <identifier>
@@ -2255,7 +2255,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999ZA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -2332,7 +2342,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37e18350-e371-11ed-1664-020000000000"/>
+      <fullUrl value="urn:uuid:073621c4-621b-11ee-2027-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_REPC_IN990101NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_REPC_IN990101NL_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="36f9719e-e371-11ed-6814-020000000000"/>
+   <id value="064d5c80-621b-11ee-2135-020000000000"/>
    <type value="searchset"/>
    <total value="2"/>
    <link>
@@ -21,8 +21,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Emfyseem/COPD</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996625 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996625 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -60,7 +59,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <encounter>
@@ -72,6 +71,12 @@
             </encounter>
             <date value="2019-01-30T16:45:00+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:064d6c18-621b-11ee-2135-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
                <display value="Huisarts 1"/>
             </author>
@@ -98,7 +103,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Gaat beter, nog wel af en toe benauwd/hoesten. Geen koorts, weinig slijm en geen PoB.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f9814c-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6c2e-621b-11ee-2135-020000000000"/>
                   <display value="S: Subjectief - Gaat beter, nog wel af en toe benauwd/hoesten. Geen koorts, weinig slijm en geen PoB."/>
                </entry>
                <entry>
@@ -122,7 +127,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Longen VAG geen crep, piep, wel wat rhonchi. Percussie gb.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f9814f-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6c31-621b-11ee-2135-020000000000"/>
                   <display value="O: Objectief - Longen VAG geen crep, piep, wel wat rhonchi. Percussie gb."/>
                </entry>
                <entry>
@@ -155,7 +160,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">COPD, beterend</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f98152-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6c34-621b-11ee-2135-020000000000"/>
                   <display value="E: Evaluatie - COPD, beterend"/>
                </entry>
                <entry>
@@ -179,7 +184,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Controle afspreken POH voor ketenzorg en blaastest, continueren flixotide, zn ventolin.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f9815c-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6c3e-621b-11ee-2135-020000000000"/>
                   <display value="P: Plan - Controle afspreken POH voor ketenzorg en blaastest, continueren flixotide, zn ventolin."/>
                </entry>
                <entry>
@@ -209,8 +214,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Emfyseem/COPD</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996626 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996626 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -248,7 +252,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <encounter>
@@ -260,6 +264,12 @@
             </encounter>
             <date value="2019-02-02T17:03:00+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:064d6c45-621b-11ee-2135-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
                <display value="Huisarts 1"/>
             </author>
@@ -286,7 +296,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Gaat slechter. Medicatie slaat niet aan aldus pat. Koorts-. Hoest+++. Slijm geel.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f97fea-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6acc-621b-11ee-2135-020000000000"/>
                   <display value="S: Subjectief - Gaat slechter. Medicatie slaat niet aan aldus pat. Koorts-. Hoest+++. Slijm geel."/>
                </entry>
                <entry>
@@ -310,7 +320,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Longen VAG crep+, piep iets, rhonchi+.  Percussie gb.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f97fed-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6acf-621b-11ee-2135-020000000000"/>
                   <display value="O: Objectief - Longen VAG crep+, piep iets, rhonchi+. Percussie gb."/>
                </entry>
                <entry>
@@ -343,7 +353,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">COPD, exacerbatie</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f97ff0-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6ad2-621b-11ee-2135-020000000000"/>
                   <display value="E: Evaluatie - COPD, exacerbatie"/>
                </entry>
                <entry>
@@ -367,7 +377,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">AB starten, ventolin 3-4 dgs.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36f97ffa-e371-11ed-6814-020000000000"/>
+                  <reference value="urn:uuid:064d6adc-621b-11ee-2135-020000000000"/>
                   <display value="P: Plan - AB starten, ventolin 3-4 dgs."/>
                </entry>
                <entry>
@@ -385,7 +395,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -395,7 +405,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -461,7 +471,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -482,6 +502,8 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 900014718 (UZI-NR-PERS), <span title="Naamsamenstelling: Eigennaam">Huisarts 1</span>
                   </div>
+                  <div>
+                     <a href="tel:030-6963207">030-6963207</a> (Tel Werk), <a href="tel:06-12345678">06-12345678</a> (Tel Werk)</div>
                </div>
             </text>
             <identifier>
@@ -498,6 +520,46 @@
                   </extension>
                </family>
             </name>
+            <telecom>
+               <system value="phone"/>
+               <value value="030-6963207"/>
+               <use value="work">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                           <code value="WP"/>
+                           <display value="Work place"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </use>
+            </telecom>
+            <telecom>
+               <system value="phone">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                           <code value="MC"/>
+                           <display value="Mobiele telefoon"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </system>
+               <value value="06-12345678"/>
+               <use value="work">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                           <code value="WP"/>
+                           <display value="Work place"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </use>
+            </telecom>
          </Practitioner>
       </resource>
       <search>
@@ -571,7 +633,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f98136-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6c18-621b-11ee-2135-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -600,7 +662,7 @@
                               <div>
                                  <a href="tel:030-6963207">030-6963207</a> (Tel Werk)</div>
                               <div>
-                                 <a href="tel:06-12345678">06-12345678</a> (Tel Work place)</div>
+                                 <a href="tel:06-12345678">06-12345678</a> (Tel Werk)</div>
                            </td>
                         </tr>
                      </tbody>
@@ -643,7 +705,7 @@
                   </extension>
                </system>
                <value value="06-12345678"/>
-               <use value="mobile">
+               <use value="work">
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                      <valueCodeableConcept>
                         <coding>
@@ -662,7 +724,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f98163-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6c45-621b-11ee-2135-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -697,7 +759,7 @@
                               <div>
                                  <a href="tel:030-6963207">030-6963207</a> (Tel Werk)</div>
                               <div>
-                                 <a href="tel:06-12345678">06-12345678</a> (Tel Work place)</div>
+                                 <a href="tel:06-12345678">06-12345678</a> (Tel Werk)</div>
                            </td>
                         </tr>
                      </tbody>
@@ -747,7 +809,7 @@
                   </extension>
                </system>
                <value value="06-12345678"/>
-               <use value="mobile">
+               <use value="work">
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                      <valueCodeableConcept>
                         <coding>
@@ -766,7 +828,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f9814c-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6c2e-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -776,7 +838,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -805,7 +869,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -815,6 +879,10 @@
                </identifier>
                <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Gaat beter, nog wel af en toe benauwd/hoesten. Geen koorts, weinig slijm en geen PoB."/>
          </Observation>
       </resource>
@@ -823,7 +891,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f9814f-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6c31-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -833,7 +901,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -862,7 +932,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -872,6 +942,10 @@
                </identifier>
                <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Longen VAG geen crep, piep, wel wat rhonchi. Percussie gb."/>
          </Observation>
       </resource>
@@ -880,7 +954,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f98152-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6c34-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -890,7 +964,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -927,7 +1003,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -937,6 +1013,10 @@
                </identifier>
                <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="COPD, beterend"/>
             <component>
                <code>
@@ -961,7 +1041,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f9815c-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6c3e-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -971,7 +1051,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -1000,7 +1082,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -1010,6 +1092,10 @@
                </identifier>
                <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Controle afspreken POH voor ketenzorg en blaastest, continueren flixotide, zn ventolin."/>
          </Observation>
       </resource>
@@ -1018,7 +1104,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f97fea-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6acc-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1028,7 +1114,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -1057,7 +1145,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -1067,6 +1155,10 @@
                </identifier>
                <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Gaat slechter. Medicatie slaat niet aan aldus pat. Koorts-. Hoest+++. Slijm geel."/>
          </Observation>
       </resource>
@@ -1075,7 +1167,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f97fed-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6acf-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1085,7 +1177,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -1114,7 +1208,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -1124,6 +1218,10 @@
                </identifier>
                <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Longen VAG crep+, piep iets, rhonchi+.  Percussie gb."/>
          </Observation>
       </resource>
@@ -1132,7 +1230,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f97ff0-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6ad2-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1142,7 +1240,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -1179,7 +1279,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -1189,6 +1289,10 @@
                </identifier>
                <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="COPD, exacerbatie"/>
             <component>
                <code>
@@ -1213,7 +1317,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36f97ffa-e371-11ed-6814-020000000000"/>
+      <fullUrl value="urn:uuid:064d6adc-621b-11ee-2135-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1223,7 +1327,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -1252,7 +1358,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36f98122-e371-11ed-6814-020000000000"/>
+               <reference value="urn:uuid:064d6c04-621b-11ee-2135-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -1262,6 +1368,10 @@
                </identifier>
                <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="AB starten, ventolin 3-4 dgs."/>
          </Observation>
       </resource>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_REPC_IN990101NL_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_REPC_IN990101NL_02.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="36fda1a6-e371-11ed-1928-020000000000"/>
+   <id value="0651f9de-621b-11ee-1252-020000000000"/>
    <type value="searchset"/>
    <total value="18"/>
    <link>
@@ -21,8 +21,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Tinea Pedis</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag09 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag09 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -60,7 +59,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -72,6 +71,12 @@
             </encounter>
             <date value="2019-09-23T10:39:46+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -107,7 +112,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Mycose</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd7fb9-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651f849-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Mycose"/>
                </entry>
                <entry>
@@ -131,7 +136,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Heeft nog canesten via drogist; 2x daags gebruiken.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd7fc3-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651f853-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Heeft nog canesten via drogist; 2x daags gebruiken."/>
                </entry>
                <entry>
@@ -161,8 +166,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag16 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag16 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -200,7 +204,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -212,6 +216,12 @@
             </encounter>
             <date value="2020-01-16"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -247,7 +257,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd7fd8-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651f868-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -271,7 +281,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Patiënt geïnformeerd, ziet het nog even aan.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd7fe2-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651f872-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Patiënt geïnformeerd, ziet het nog even aan."/>
                </entry>
                <entry>
@@ -301,8 +311,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag13 (urn:oid:2.16.840.1.113883.2.4.3.111.19.1), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag13 (urn:oid:2.16.840.1.113883.2.4.3.111.19.1), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -340,7 +349,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -352,6 +361,12 @@
             </encounter>
             <date value="2020-03-01"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -387,7 +402,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8a83-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e6f3-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -417,8 +432,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag17 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag17 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -456,7 +470,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -468,6 +482,12 @@
             </encounter>
             <date value="2020-02-25"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -503,7 +523,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8aa0-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e710-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -527,7 +547,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Nogmaals verwijzing Cesar</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8aaa-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e71a-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Nogmaals verwijzing Cesar"/>
                </entry>
                <entry>
@@ -557,8 +577,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag12 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag12 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -596,7 +615,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -608,6 +627,12 @@
             </encounter>
             <date value="2020-01-21"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -643,7 +668,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8abf-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e72f-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -667,7 +692,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Bezoek brengen aan de tandarts, wellicht zit er daar iets.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8ac9-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e739-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Bezoek brengen aan de tandarts, wellicht zit er daar iets."/>
                </entry>
                <entry>
@@ -697,8 +722,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag15 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag15 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -736,7 +760,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -748,6 +772,12 @@
             </encounter>
             <date value="2020-01-11"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -783,7 +813,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8ade-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e74e-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -807,7 +837,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Scan laten maken, afspraak gepland.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8ae8-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e758-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Scan laten maken, afspraak gepland."/>
                </entry>
                <entry>
@@ -837,8 +867,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag14 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag14 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -876,7 +905,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -888,6 +917,12 @@
             </encounter>
             <date value="2019-12-22"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -923,7 +958,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Lage rugpijn</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8afd-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e76d-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Lage rugpijn"/>
                </entry>
                <entry>
@@ -947,7 +982,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Cesar of Mensendieck. Verwijzing aangemaakt</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b07-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e777-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Cesar of Mensendieck. Verwijzing aangemaakt"/>
                </entry>
                <entry>
@@ -977,8 +1012,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Maagpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag07 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag07 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1016,7 +1050,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1028,6 +1062,12 @@
             </encounter>
             <date value="2019-12-07"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1063,7 +1103,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Maag/duodenum problemen?</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b1c-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e78c-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Maag/duodenum problemen?"/>
                </entry>
                <entry>
@@ -1093,8 +1133,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag10 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag10 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1132,7 +1171,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1144,6 +1183,12 @@
             </encounter>
             <date value="2019-11-17"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1179,7 +1224,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b39-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e7a9-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -1203,7 +1248,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Afwachten, zn. Medicatie is nog beschikbaar</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b43-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e7b3-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Afwachten, zn. Medicatie is nog beschikbaar"/>
                </entry>
                <entry>
@@ -1233,8 +1278,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag04 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag04 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1272,7 +1316,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1284,6 +1328,12 @@
             </encounter>
             <date value="2019-11-12"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1319,7 +1369,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">lage rugpijn</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b58-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e7c8-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - lage rugpijn"/>
                </entry>
                <entry>
@@ -1349,8 +1399,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag06 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag06 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1388,7 +1437,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1400,6 +1449,12 @@
             </encounter>
             <date value="2019-10-13T10:39:46+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1435,7 +1490,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b75-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e7e5-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -1459,7 +1514,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Afwachten, zn. Pcm, tijdens feest paracod.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b7f-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e7ef-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Afwachten, zn. Pcm, tijdens feest paracod."/>
                </entry>
                <entry>
@@ -1489,8 +1544,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Astma</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslagMMK (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslagMMK (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1528,7 +1582,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1540,6 +1594,12 @@
             </encounter>
             <date value="2019-10-03T10:39:46+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1575,7 +1635,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">astma</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b94-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e804-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - astma"/>
                </entry>
                <entry>
@@ -1599,7 +1659,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Salbutamol half uur voor het sporten.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8b9e-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e80e-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Salbutamol half uur voor het sporten."/>
                </entry>
                <entry>
@@ -1629,8 +1689,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag H. XXX_Mulders</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag08 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag08 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1668,7 +1727,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1680,6 +1739,12 @@
             </encounter>
             <date value="2019-09-18T10:39:46+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1706,7 +1771,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8bb3-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e823-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl."/>
                </entry>
                <entry>
@@ -1730,7 +1795,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Echo</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8bb6-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e826-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Echo"/>
                </entry>
                <entry>
@@ -1760,8 +1825,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag H. XXX_Mulders</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag03 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag03 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1795,7 +1859,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1807,6 +1871,12 @@
             </encounter>
             <date value="2019-03-17"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1824,7 +1894,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Over paar weken RR thuis.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8bca-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e83a-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Over paar weken RR thuis."/>
                </entry>
             </section>
@@ -1847,8 +1917,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag H. XXX_Mulders</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag02 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag02 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1882,7 +1951,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1894,6 +1963,12 @@
             </encounter>
             <date value="2019-02-25"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1911,7 +1986,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Na vakantie nogmaals.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8bde-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e84e-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Na vakantie nogmaals."/>
                </entry>
             </section>
@@ -1934,8 +2009,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Boezemfibrilleren/-fladderen</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag01 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag01 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1973,7 +2047,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1985,6 +2059,12 @@
             </encounter>
             <date value="2019-02-05"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2020,7 +2100,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Ritmestoornis</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8bf3-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e863-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Ritmestoornis"/>
                </entry>
                <entry>
@@ -2044,7 +2124,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Naar SEH.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8bfd-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e86d-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Naar SEH."/>
                </entry>
                <entry>
@@ -2074,8 +2154,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag11 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag11 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -2113,7 +2192,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -2125,6 +2204,12 @@
             </encounter>
             <date value="2019-12-12"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2160,7 +2245,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8c12-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e882-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -2184,7 +2269,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Kweek van aanslag keel</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8c1c-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e88c-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Kweek van aanslag keel"/>
                </entry>
                <entry>
@@ -2214,8 +2299,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag05 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag05 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -2253,7 +2337,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -2265,6 +2349,12 @@
             </encounter>
             <date value="2019-12-02"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2300,7 +2390,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Maag/duodenum problemen?</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8c31-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e8a1-621b-11ee-1252-020000000000"/>
                   <display value="E: Evaluatie - Maag/duodenum problemen?"/>
                </entry>
                <entry>
@@ -2324,7 +2414,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Cesar of Mensendieck.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:36fd8c3b-e371-11ed-1928-020000000000"/>
+                  <reference value="urn:uuid:0651e8ab-621b-11ee-1252-020000000000"/>
                   <display value="P: Plan - Cesar of Mensendieck."/>
                </entry>
                <entry>
@@ -2342,7 +2432,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -2352,7 +2442,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">H. XXX_Mulders</span>, Man, 30 december 1985</div>
-                  <div>Knolweg 1003, 9999ZA STITSWERD, Nederland</div>
+                  <div>Knolweg 1003, 9999ZA STITSWERD, NL</div>
                </div>
             </text>
             <identifier>
@@ -2401,7 +2491,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999ZA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -2478,7 +2578,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd7fab-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651f83b-621b-11ee-1252-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -2533,7 +2633,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd7fb9-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651f849-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2543,7 +2643,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2580,7 +2682,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2590,6 +2692,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Mycose"/>
             <component>
                <code>
@@ -2614,7 +2720,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd7fc3-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651f853-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2624,7 +2730,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2653,7 +2761,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2663,6 +2771,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Heeft nog canesten via drogist; 2x daags gebruiken."/>
          </Observation>
       </resource>
@@ -2671,7 +2783,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd7fd8-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651f868-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2681,7 +2793,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2718,7 +2832,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2728,6 +2842,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -2752,7 +2870,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd7fe2-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651f872-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2762,7 +2880,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2791,7 +2911,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2801,6 +2921,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Patiënt geïnformeerd, ziet het nog even aan."/>
          </Observation>
       </resource>
@@ -2809,7 +2933,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8a83-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e6f3-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2819,7 +2943,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2856,7 +2982,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2866,6 +2992,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment13 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -2890,7 +3020,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8aa0-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e710-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2900,7 +3030,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2937,7 +3069,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2947,6 +3079,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -2971,7 +3107,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8aaa-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e71a-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2981,7 +3117,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3010,7 +3148,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3020,6 +3158,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Nogmaals verwijzing Cesar"/>
          </Observation>
       </resource>
@@ -3028,7 +3170,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8abf-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e72f-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3038,7 +3180,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3075,7 +3219,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3085,6 +3229,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -3109,7 +3257,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8ac9-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e739-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3119,7 +3267,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3148,7 +3298,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3158,6 +3308,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Bezoek brengen aan de tandarts, wellicht zit er daar iets."/>
          </Observation>
       </resource>
@@ -3166,7 +3320,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8ade-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e74e-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3176,7 +3330,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3213,7 +3369,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3223,6 +3379,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -3247,7 +3407,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8ae8-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e758-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3257,7 +3417,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3286,7 +3448,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3296,6 +3458,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Scan laten maken, afspraak gepland."/>
          </Observation>
       </resource>
@@ -3304,7 +3470,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8afd-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e76d-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3314,7 +3480,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3351,7 +3519,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3361,6 +3529,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Lage rugpijn"/>
             <component>
                <code>
@@ -3385,7 +3557,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b07-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e777-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3395,7 +3567,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3424,7 +3598,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3434,6 +3608,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Cesar of Mensendieck. Verwijzing aangemaakt"/>
          </Observation>
       </resource>
@@ -3442,7 +3620,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b1c-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e78c-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3452,7 +3630,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3489,7 +3669,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3499,6 +3679,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment07 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Maag/duodenum problemen?"/>
             <component>
                <code>
@@ -3523,7 +3707,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b39-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e7a9-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3533,7 +3717,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3570,7 +3756,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3580,6 +3766,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -3604,7 +3794,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b43-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e7b3-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3614,7 +3804,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3643,7 +3835,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3653,6 +3845,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Afwachten, zn. Medicatie is nog beschikbaar"/>
          </Observation>
       </resource>
@@ -3661,7 +3857,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b58-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e7c8-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3671,7 +3867,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3708,7 +3906,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3718,6 +3916,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment04 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="lage rugpijn"/>
             <component>
                <code>
@@ -3742,7 +3944,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b75-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e7e5-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3752,7 +3954,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3789,7 +3993,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3799,6 +4003,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -3823,7 +4031,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b7f-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e7ef-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3833,7 +4041,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3862,7 +4072,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3872,6 +4082,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Afwachten, zn. Pcm, tijdens feest paracod."/>
          </Observation>
       </resource>
@@ -3880,7 +4094,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b94-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e804-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3890,7 +4104,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3927,7 +4143,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3937,6 +4153,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="astma"/>
             <component>
                <code>
@@ -3961,7 +4181,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8b9e-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e80e-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3971,7 +4191,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4000,7 +4222,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4010,6 +4232,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Salbutamol half uur voor het sporten."/>
          </Observation>
       </resource>
@@ -4018,7 +4244,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8bb3-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e823-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4028,7 +4254,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4057,7 +4285,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4067,6 +4295,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl."/>
          </Observation>
       </resource>
@@ -4075,7 +4307,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8bb6-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e826-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4085,7 +4317,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4114,7 +4348,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4124,6 +4358,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Echo"/>
          </Observation>
       </resource>
@@ -4132,7 +4370,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8bca-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e83a-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4142,7 +4380,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4171,7 +4411,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4181,6 +4421,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment03 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Over paar weken RR thuis."/>
          </Observation>
       </resource>
@@ -4189,7 +4433,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8bde-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e84e-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4199,7 +4443,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4228,7 +4474,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4238,6 +4484,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment02 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Na vakantie nogmaals."/>
          </Observation>
       </resource>
@@ -4246,7 +4496,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8bf3-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e863-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4256,7 +4506,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4293,7 +4545,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4303,6 +4555,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Ritmestoornis"/>
             <component>
                <code>
@@ -4327,7 +4583,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8bfd-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e86d-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4337,7 +4593,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4366,7 +4624,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4376,6 +4634,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Naar SEH."/>
          </Observation>
       </resource>
@@ -4384,7 +4646,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8c12-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e882-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4394,7 +4656,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4431,7 +4695,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4441,6 +4705,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -4465,7 +4733,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8c1c-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e88c-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4475,7 +4743,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4504,7 +4774,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4514,6 +4784,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Kweek van aanslag keel"/>
          </Observation>
       </resource>
@@ -4522,7 +4796,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8c31-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e8a1-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4532,7 +4806,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4569,7 +4845,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4579,6 +4855,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Maag/duodenum problemen?"/>
             <component>
                <code>
@@ -4603,7 +4883,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36fd8c3b-e371-11ed-1928-020000000000"/>
+      <fullUrl value="urn:uuid:0651e8ab-621b-11ee-1252-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4613,7 +4893,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4642,7 +4924,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36fd7f98-e371-11ed-1928-020000000000"/>
+               <reference value="urn:uuid:0651f828-621b-11ee-1252-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4652,6 +4934,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Cesar of Mensendieck."/>
          </Observation>
       </resource>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_REPC_IN990101NL_03.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_REPC_IN990101NL_03.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="37076556-e371-11ed-4818-020000000000"/>
+   <id value="065b99f8-621b-11ee-6695-020000000000"/>
    <type value="searchset"/>
    <total value="18"/>
    <link>
@@ -21,8 +21,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Tinea Pedis</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag09 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag09 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -60,7 +59,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -72,6 +71,12 @@
             </encounter>
             <date value="2019-10-08T15:41:54+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -107,7 +112,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Mycose</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077145-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb591-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Mycose"/>
                </entry>
                <entry>
@@ -131,7 +136,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Heeft nog canesten via drogist; 2x daags gebruiken.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707714f-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb59b-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Heeft nog canesten via drogist; 2x daags gebruiken."/>
                </entry>
                <entry>
@@ -161,8 +166,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag16 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag16 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -200,7 +204,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -212,6 +216,12 @@
             </encounter>
             <date value="2020-01-31T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -247,7 +257,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077164-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb5b0-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -271,7 +281,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Patiënt geïnformeerd, ziet het nog even aan.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707716e-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb5ba-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Patiënt geïnformeerd, ziet het nog even aan."/>
                </entry>
                <entry>
@@ -301,8 +311,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag13 (urn:oid:2.16.840.1.113883.2.4.3.111.19.1), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag13 (urn:oid:2.16.840.1.113883.2.4.3.111.19.1), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -340,7 +349,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -352,6 +361,12 @@
             </encounter>
             <date value="2020-03-16T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -387,7 +402,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:370771e7-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb697-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -417,8 +432,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag17 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag17 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -456,7 +470,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -468,6 +482,12 @@
             </encounter>
             <date value="2020-03-11T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -503,7 +523,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077204-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb6b4-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -527,7 +547,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Nogmaals verwijzing Cesar</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707720e-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb6be-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Nogmaals verwijzing Cesar"/>
                </entry>
                <entry>
@@ -557,8 +577,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag12 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag12 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -596,7 +615,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -608,6 +627,12 @@
             </encounter>
             <date value="2020-02-05T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -643,7 +668,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077223-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb6d3-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -667,7 +692,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Bezoek brengen aan de tandarts, wellicht zit er daar iets.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707722d-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb6dd-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Bezoek brengen aan de tandarts, wellicht zit er daar iets."/>
                </entry>
                <entry>
@@ -697,8 +722,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag15 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag15 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -736,7 +760,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -748,6 +772,12 @@
             </encounter>
             <date value="2020-01-26T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -783,7 +813,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077242-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb6f2-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -807,7 +837,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Scan laten maken, afspraak gepland.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707724c-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb6fc-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Scan laten maken, afspraak gepland."/>
                </entry>
                <entry>
@@ -837,8 +867,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag14 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag14 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -876,7 +905,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -888,6 +917,12 @@
             </encounter>
             <date value="2020-01-06T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -923,7 +958,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Lage rugpijn</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077261-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb711-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Lage rugpijn"/>
                </entry>
                <entry>
@@ -947,7 +982,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Cesar of Mensendieck. Verwijzing aangemaakt</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707726b-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb71b-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Cesar of Mensendieck. Verwijzing aangemaakt"/>
                </entry>
                <entry>
@@ -977,8 +1012,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Maagpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag07 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag07 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1016,7 +1050,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1028,6 +1062,12 @@
             </encounter>
             <date value="2019-12-22T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1063,7 +1103,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Maag/duodenum problemen?</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077280-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb730-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Maag/duodenum problemen?"/>
                </entry>
                <entry>
@@ -1093,8 +1133,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag10 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag10 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1132,7 +1171,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1144,6 +1183,12 @@
             </encounter>
             <date value="2019-12-02T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1179,7 +1224,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707729d-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb74d-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -1203,7 +1248,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Afwachten, zn. Medicatie is nog beschikbaar</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:370772a7-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb757-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Afwachten, zn. Medicatie is nog beschikbaar"/>
                </entry>
                <entry>
@@ -1233,8 +1278,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag04 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag04 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1272,7 +1316,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1284,6 +1328,12 @@
             </encounter>
             <date value="2019-11-27T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1319,7 +1369,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">lage rugpijn</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:370772bc-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb76c-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - lage rugpijn"/>
                </entry>
                <entry>
@@ -1349,8 +1399,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag06 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag06 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1388,7 +1437,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1400,6 +1449,12 @@
             </encounter>
             <date value="2019-10-28T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1435,7 +1490,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:370772d9-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb789-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -1459,7 +1514,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Afwachten, zn. Pcm, tijdens feest paracod.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:370772e3-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb793-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Afwachten, zn. Pcm, tijdens feest paracod."/>
                </entry>
                <entry>
@@ -1489,8 +1544,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Astma</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslagMMK (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslagMMK (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1528,7 +1582,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1540,6 +1594,12 @@
             </encounter>
             <date value="2019-10-18T15:41:54+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1575,7 +1635,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">astma</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:370772f8-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb7a8-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - astma"/>
                </entry>
                <entry>
@@ -1599,7 +1659,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Salbutamol half uur voor het sporten.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077302-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb7b2-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Salbutamol half uur voor het sporten."/>
                </entry>
                <entry>
@@ -1629,8 +1689,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag H. XXX_Mulders</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag08 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag08 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1668,7 +1727,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1680,6 +1739,12 @@
             </encounter>
             <date value="2019-10-03T15:41:54+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1706,7 +1771,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077317-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb7c7-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl."/>
                </entry>
                <entry>
@@ -1730,7 +1795,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Echo</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707731a-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb7ca-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Echo"/>
                </entry>
                <entry>
@@ -1760,8 +1825,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag H. XXX_Mulders</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag03 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag03 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1795,7 +1859,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1807,6 +1871,12 @@
             </encounter>
             <date value="2019-04-01T15:41:54+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1824,7 +1894,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Over paar weken RR thuis.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707732e-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb7de-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Over paar weken RR thuis."/>
                </entry>
             </section>
@@ -1847,8 +1917,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag H. XXX_Mulders</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag02 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag02 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1882,7 +1951,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1894,6 +1963,12 @@
             </encounter>
             <date value="2019-03-12T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1911,7 +1986,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Na vakantie nogmaals.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077342-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb7f2-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Na vakantie nogmaals."/>
                </entry>
             </section>
@@ -1934,8 +2009,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Boezemfibrilleren/-fladderen</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag01 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag01 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1973,7 +2047,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -1985,6 +2059,12 @@
             </encounter>
             <date value="2019-02-20T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2020,7 +2100,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Ritmestoornis</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077357-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb807-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Ritmestoornis"/>
                </entry>
                <entry>
@@ -2044,7 +2124,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Naar SEH.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077361-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb811-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Naar SEH."/>
                </entry>
                <entry>
@@ -2074,8 +2154,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag11 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag11 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -2113,7 +2192,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -2125,6 +2204,12 @@
             </encounter>
             <date value="2019-12-27T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2160,7 +2245,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077376-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb826-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -2184,7 +2269,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Kweek van aanslag keel</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077380-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb830-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Kweek van aanslag keel"/>
                </entry>
                <entry>
@@ -2214,8 +2299,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag05 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: H. XXX_Mulders. Id: MedMijHG-contactverslag05 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -2253,7 +2337,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <encounter>
@@ -2265,6 +2349,12 @@
             </encounter>
             <date value="2019-12-17T14:41:54+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2300,7 +2390,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Maag/duodenum problemen?</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37077395-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb845-621b-11ee-6695-020000000000"/>
                   <display value="E: Evaluatie - Maag/duodenum problemen?"/>
                </entry>
                <entry>
@@ -2324,7 +2414,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Cesar of Mensendieck.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3707739f-e371-11ed-4818-020000000000"/>
+                  <reference value="urn:uuid:065bb84f-621b-11ee-6695-020000000000"/>
                   <display value="P: Plan - Cesar of Mensendieck."/>
                </entry>
                <entry>
@@ -2342,7 +2432,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -2352,7 +2442,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">H. XXX_Mulders</span>, Man, 30 december 1985</div>
-                  <div>Knolweg 1003, 9999ZA STITSWERD, Nederland</div>
+                  <div>Knolweg 1003, 9999ZA STITSWERD, NL</div>
                </div>
             </text>
             <identifier>
@@ -2401,7 +2491,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999ZA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -2478,7 +2578,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077137-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb583-621b-11ee-6695-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -2533,7 +2633,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077145-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb591-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2543,7 +2643,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2580,7 +2682,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2590,6 +2692,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Mycose"/>
             <component>
                <code>
@@ -2614,7 +2720,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707714f-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb59b-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2624,7 +2730,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2653,7 +2761,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2663,6 +2771,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Heeft nog canesten via drogist; 2x daags gebruiken."/>
          </Observation>
       </resource>
@@ -2671,7 +2783,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077164-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb5b0-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2681,7 +2793,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2718,7 +2832,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2728,6 +2842,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -2752,7 +2870,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707716e-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb5ba-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2762,7 +2880,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2791,7 +2911,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2801,6 +2921,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Patiënt geïnformeerd, ziet het nog even aan."/>
          </Observation>
       </resource>
@@ -2809,7 +2933,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:370771e7-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb697-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2819,7 +2943,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2856,7 +2982,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2866,6 +2992,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment13 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -2890,7 +3020,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077204-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb6b4-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2900,7 +3030,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -2937,7 +3069,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -2947,6 +3079,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -2971,7 +3107,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707720e-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb6be-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -2981,7 +3117,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3010,7 +3148,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3020,6 +3158,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Nogmaals verwijzing Cesar"/>
          </Observation>
       </resource>
@@ -3028,7 +3170,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077223-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb6d3-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3038,7 +3180,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3075,7 +3219,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3085,6 +3229,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -3109,7 +3257,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707722d-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb6dd-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3119,7 +3267,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3148,7 +3298,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3158,6 +3308,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Bezoek brengen aan de tandarts, wellicht zit er daar iets."/>
          </Observation>
       </resource>
@@ -3166,7 +3320,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077242-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb6f2-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3176,7 +3330,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3213,7 +3369,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3223,6 +3379,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -3247,7 +3407,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707724c-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb6fc-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3257,7 +3417,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3286,7 +3448,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3296,6 +3458,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Scan laten maken, afspraak gepland."/>
          </Observation>
       </resource>
@@ -3304,7 +3470,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077261-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb711-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3314,7 +3480,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3351,7 +3519,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3361,6 +3529,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Lage rugpijn"/>
             <component>
                <code>
@@ -3385,7 +3557,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707726b-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb71b-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3395,7 +3567,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3424,7 +3598,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3434,6 +3608,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Cesar of Mensendieck. Verwijzing aangemaakt"/>
          </Observation>
       </resource>
@@ -3442,7 +3620,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077280-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb730-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3452,7 +3630,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3489,7 +3669,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3499,6 +3679,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment07 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Maag/duodenum problemen?"/>
             <component>
                <code>
@@ -3523,7 +3707,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707729d-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb74d-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3533,7 +3717,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3570,7 +3756,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3580,6 +3766,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -3604,7 +3794,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:370772a7-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb757-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3614,7 +3804,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3643,7 +3835,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3653,6 +3845,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Afwachten, zn. Medicatie is nog beschikbaar"/>
          </Observation>
       </resource>
@@ -3661,7 +3857,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:370772bc-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb76c-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3671,7 +3867,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3708,7 +3906,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3718,6 +3916,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment04 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="lage rugpijn"/>
             <component>
                <code>
@@ -3742,7 +3944,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:370772d9-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb789-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3752,7 +3954,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3789,7 +3993,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3799,6 +4003,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -3823,7 +4031,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:370772e3-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb793-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3833,7 +4041,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3862,7 +4072,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3872,6 +4082,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Afwachten, zn. Pcm, tijdens feest paracod."/>
          </Observation>
       </resource>
@@ -3880,7 +4094,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:370772f8-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb7a8-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3890,7 +4104,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -3927,7 +4143,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -3937,6 +4153,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="astma"/>
             <component>
                <code>
@@ -3961,7 +4181,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077302-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb7b2-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -3971,7 +4191,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4000,7 +4222,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4010,6 +4232,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Salbutamol half uur voor het sporten."/>
          </Observation>
       </resource>
@@ -4018,7 +4244,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077317-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb7c7-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4028,7 +4254,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4057,7 +4285,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4067,6 +4295,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl."/>
          </Observation>
       </resource>
@@ -4075,7 +4307,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707731a-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb7ca-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4085,7 +4317,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4114,7 +4348,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4124,6 +4358,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Echo"/>
          </Observation>
       </resource>
@@ -4132,7 +4370,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707732e-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb7de-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4142,7 +4380,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4171,7 +4411,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4181,6 +4421,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment03 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Over paar weken RR thuis."/>
          </Observation>
       </resource>
@@ -4189,7 +4433,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077342-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb7f2-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4199,7 +4443,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4228,7 +4474,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4238,6 +4484,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment02 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Na vakantie nogmaals."/>
          </Observation>
       </resource>
@@ -4246,7 +4496,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077357-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb807-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4256,7 +4506,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4293,7 +4545,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4303,6 +4555,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Ritmestoornis"/>
             <component>
                <code>
@@ -4327,7 +4583,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077361-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb811-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4337,7 +4593,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4366,7 +4624,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4376,6 +4634,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Naar SEH."/>
          </Observation>
       </resource>
@@ -4384,7 +4646,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077376-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb826-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4394,7 +4656,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4431,7 +4695,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4441,6 +4705,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -4465,7 +4733,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077380-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb830-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4475,7 +4743,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4504,7 +4774,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4514,6 +4784,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Kweek van aanslag keel"/>
          </Observation>
       </resource>
@@ -4522,7 +4796,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37077395-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb845-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4532,7 +4806,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4569,7 +4845,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4579,6 +4855,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Maag/duodenum problemen?"/>
             <component>
                <code>
@@ -4603,7 +4883,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3707739f-e371-11ed-4818-020000000000"/>
+      <fullUrl value="urn:uuid:065bb84f-621b-11ee-6695-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4613,7 +4893,9 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: H. XXX_Mulders. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -4642,7 +4924,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37077124-e371-11ed-4818-020000000000"/>
+               <reference value="urn:uuid:065bb570-621b-11ee-6695-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -4652,6 +4934,10 @@
                </identifier>
                <display value="Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Cesar of Mensendieck."/>
          </Observation>
       </resource>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_bundle_01_met_contacten.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_bundle_01_met_contacten.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="371007c4-e371-11ed-1071-020000000000"/>
+   <id value="0664ac5a-621b-11ee-1978-020000000000"/>
    <type value="searchset"/>
    <total value="2"/>
    <link>
@@ -21,8 +21,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Emfyseem/COPD</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996625 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996625 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: XIS test || Tést Zorginstelling 02</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -37,7 +36,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 03-02-2019</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -60,15 +59,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <encounter>
-               <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996625"/>
-               <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <reference value="Encounter/d8db035c-6214-11ee-5414-020000000000"/>
+               <display value="Contact: consult met XIS test op 03-02-2019"/>
             </encounter>
             <date value="2019-01-30T16:45:00+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0664be04-621b-11ee-1978-020000000000"/>
+                     <display value="XIS test || Tést Zorginstelling 02"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
                <display value="XIS test"/>
             </author>
@@ -95,7 +100,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Gaat beter, nog wel af en toe benauwd/hoesten. Geen koorts, weinig slijm en geen PoB.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101a7f-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be11-621b-11ee-1978-020000000000"/>
                   <display value="S: Subjectief - Gaat beter, nog wel af en toe benauwd/hoesten. Geen koorts, weinig slijm en geen PoB."/>
                </entry>
                <entry>
@@ -119,7 +124,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Longen VAG geen crep, piep, wel wat rhonchi. Percussie gb.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101a82-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be14-621b-11ee-1978-020000000000"/>
                   <display value="O: Objectief - Longen VAG geen crep, piep, wel wat rhonchi. Percussie gb."/>
                </entry>
                <entry>
@@ -152,7 +157,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">COPD, beterend</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101a85-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be17-621b-11ee-1978-020000000000"/>
                   <display value="E: Evaluatie - COPD, beterend"/>
                </entry>
                <entry>
@@ -185,7 +190,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">COPD, beterend</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101a85-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be17-621b-11ee-1978-020000000000"/>
                   <display value="E: Evaluatie - COPD, beterend"/>
                </entry>
                <entry>
@@ -209,7 +214,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Controle afspreken POH voor ketenzorg en blaastest, continueren flixotide, zn ventolin.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101a99-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be2b-621b-11ee-1978-020000000000"/>
                   <display value="P: Plan - Controle afspreken POH voor ketenzorg en blaastest, continueren flixotide, zn ventolin."/>
                </entry>
                <entry>
@@ -239,8 +244,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Emfyseem/COPD</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996626 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: E. XXX_Zegers. Id: 996626 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.1), Status: definitief<span style="display: block;">Auteur: XIS test || Tést Zorginstelling 02</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -255,7 +259,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 06-02-2019</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -278,15 +282,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996626"/>
-               <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <display value="Contact: consult met XIS test op 06-02-2019"/>
             </encounter>
             <date value="2019-02-02T17:03:00+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:0664be04-621b-11ee-1978-020000000000"/>
+                     <display value="XIS test || Tést Zorginstelling 02"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
                <display value="XIS test"/>
             </author>
@@ -313,7 +323,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Gaat slechter. Medicatie slaat niet aan aldus pat. Koorts-. Hoest+++. Slijm geel.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101aad-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be3f-621b-11ee-1978-020000000000"/>
                   <display value="S: Subjectief - Gaat slechter. Medicatie slaat niet aan aldus pat. Koorts-. Hoest+++. Slijm geel."/>
                </entry>
                <entry>
@@ -337,7 +347,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Longen VAG crep+, piep iets, rhonchi+.  Percussie gb.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101ab0-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be42-621b-11ee-1978-020000000000"/>
                   <display value="O: Objectief - Longen VAG crep+, piep iets, rhonchi+. Percussie gb."/>
                </entry>
                <entry>
@@ -370,7 +380,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">COPD, exacerbatie</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:37101ab3-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664be45-621b-11ee-1978-020000000000"/>
                   <display value="E: Evaluatie - COPD, exacerbatie"/>
                </entry>
                <entry>
@@ -394,7 +404,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">AB starten, ventolin 3-4 dgs.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:371010f9-e371-11ed-1071-020000000000"/>
+                  <reference value="urn:uuid:0664aa63-621b-11ee-1978-020000000000"/>
                   <display value="P: Plan - AB starten, ventolin 3-4 dgs."/>
                </entry>
                <entry>
@@ -412,10 +422,10 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="https://example.org/fhir/Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996625"/>
+      <fullUrl value="https://example.org/fhir/Encounter/d8db035c-6214-11ee-5414-020000000000"/>
       <resource>
          <Encounter>
-            <id value="2.16.840.1.113883.2.4.6.6.90000258.4.10-996625"/>
+            <id value="d8db035c-6214-11ee-5414-020000000000"/>
             <meta>
                <profile value="http://nictiz.nl/fhir/StructureDefinition/gp-Encounter"/>
             </meta>
@@ -423,7 +433,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Contact. Subject: E. XXX_Zegers. Id: 996625 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.10), Status: voltooid</caption>
+                     <caption>Contact. Subject: E. XXX_Zegers. Id: d8db035c-6214-11ee-5414-020000000000 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.10), Status: voltooid</caption>
                      <tbody>
                         <tr>
                            <th>Type contact</th>
@@ -455,7 +465,7 @@
             </text>
             <identifier>
                <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
-               <value value="996625"/>
+               <value value="d8db035c-6214-11ee-5414-020000000000"/>
             </identifier>
             <status value="finished"/>
             <class>
@@ -482,7 +492,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <episodeOfCare>
@@ -503,7 +513,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3710111a-e371-11ed-1071-020000000000"/>
+                        <reference value="urn:uuid:0664aa84-621b-11ee-1978-020000000000"/>
                         <display value="XIS test || Huisarts || Tést Zorginstelling 02"/>
                      </valueReference>
                   </extension>
@@ -516,7 +526,7 @@
                <end value="2019-02-03T16:51:00+01:00"/>
             </period>
             <serviceProvider>
-               <reference value="urn:uuid:37101a78-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664be0a-621b-11ee-1978-020000000000"/>
                <display value="Tést Zorginstelling 02"/>
             </serviceProvider>
          </Encounter>
@@ -596,7 +606,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <episodeOfCare>
@@ -617,7 +627,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3710111a-e371-11ed-1071-020000000000"/>
+                        <reference value="urn:uuid:0664aa84-621b-11ee-1978-020000000000"/>
                         <display value="XIS test || Huisarts || Tést Zorginstelling 02"/>
                      </valueReference>
                   </extension>
@@ -630,7 +640,7 @@
                <end value="2019-02-06T17:08:00+01:00"/>
             </period>
             <serviceProvider>
-               <reference value="urn:uuid:37101a78-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664be0a-621b-11ee-1978-020000000000"/>
                <display value="Tést Zorginstelling 02"/>
             </serviceProvider>
          </Encounter>
@@ -640,7 +650,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -650,7 +660,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -716,7 +726,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -793,7 +813,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101a78-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be0a-621b-11ee-1978-020000000000"/>
       <resource>
          <Organization>
             <meta>
@@ -825,7 +845,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101a72-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be04-621b-11ee-1978-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -855,7 +875,7 @@
                <display value="XIS test"/>
             </practitioner>
             <organization>
-               <reference value="urn:uuid:37101a78-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664be0a-621b-11ee-1978-020000000000"/>
                <display value="Tést Zorginstelling 02"/>
             </organization>
          </PractitionerRole>
@@ -865,7 +885,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3710111a-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664aa84-621b-11ee-1978-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -901,7 +921,7 @@
                <display value="XIS test"/>
             </practitioner>
             <organization>
-               <reference value="urn:uuid:37101a78-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664be0a-621b-11ee-1978-020000000000"/>
                <display value="Tést Zorginstelling 02"/>
             </organization>
             <specialty>
@@ -918,7 +938,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101a7f-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be11-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -928,11 +948,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 03-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -957,13 +979,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
-               <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996625"/>
-               <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <reference value="Encounter/d8db035c-6214-11ee-5414-020000000000"/>
+               <display value="Contact: consult met XIS test op 03-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="Gaat beter, nog wel af en toe benauwd/hoesten. Geen koorts, weinig slijm en geen PoB."/>
          </Observation>
       </resource>
@@ -972,7 +998,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101a82-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be14-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -982,11 +1008,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 03-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -1011,13 +1039,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
-               <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996625"/>
-               <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <reference value="Encounter/d8db035c-6214-11ee-5414-020000000000"/>
+               <display value="Contact: consult met XIS test op 03-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="Longen VAG geen crep, piep, wel wat rhonchi. Percussie gb."/>
          </Observation>
       </resource>
@@ -1026,7 +1058,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101a85-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be17-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1036,11 +1068,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 03-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -1073,13 +1107,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
-               <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996625"/>
-               <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <reference value="Encounter/d8db035c-6214-11ee-5414-020000000000"/>
+               <display value="Contact: consult met XIS test op 03-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="COPD, beterend"/>
             <component>
                <code>
@@ -1104,7 +1142,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101a99-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be2b-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1114,11 +1152,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 03-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -1143,13 +1183,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
-               <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996625"/>
-               <display value="Contact ID: 996625 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <reference value="Encounter/d8db035c-6214-11ee-5414-020000000000"/>
+               <display value="Contact: consult met XIS test op 03-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="Controle afspreken POH voor ketenzorg en blaastest, continueren flixotide, zn ventolin."/>
          </Observation>
       </resource>
@@ -1158,7 +1202,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101aad-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be3f-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1168,11 +1212,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 06-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -1197,13 +1243,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996626"/>
-               <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <display value="Contact: consult met XIS test op 06-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="Gaat slechter. Medicatie slaat niet aan aldus pat. Koorts-. Hoest+++. Slijm geel."/>
          </Observation>
       </resource>
@@ -1212,7 +1262,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101ab0-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be42-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1222,11 +1272,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 06-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -1251,13 +1303,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996626"/>
-               <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <display value="Contact: consult met XIS test op 06-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="Longen VAG crep+, piep iets, rhonchi+.  Percussie gb."/>
          </Observation>
       </resource>
@@ -1266,7 +1322,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:37101ab3-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664be45-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1276,11 +1332,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 06-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -1313,13 +1371,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996626"/>
-               <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <display value="Contact: consult met XIS test op 06-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="COPD, exacerbatie"/>
             <component>
                <code>
@@ -1344,7 +1406,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:371010f9-e371-11ed-1071-020000000000"/>
+      <fullUrl value="urn:uuid:0664aa63-621b-11ee-1978-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1354,11 +1416,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718">XIS test</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10</td>
+                           <td>Contact: consult met XIS test op 06-02-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -1383,13 +1447,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:37101a5e-e371-11ed-1071-020000000000"/>
+               <reference value="urn:uuid:0664bdf0-621b-11ee-1978-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.6.6.90000258.4.10-996626"/>
-               <display value="Contact ID: 996626 2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <display value="Contact: consult met XIS test op 06-02-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
+               <display value="XIS test"/>
+            </performer>
             <valueString value="AB starten, ventolin 3-4 dgs."/>
          </Observation>
       </resource>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_bundle_02_met_contacten.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_bundle_02_met_contacten.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="37128a08-e371-11ed-1879-020000000000"/>
+   <id value="066926f4-621b-11ee-2059-020000000000"/>
    <type value="searchset"/>
    <total value="0"/>
    <link>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_bundle_03_met_contacten.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/contactverslag_bundle_03_met_contacten.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="3712cb26-e371-11ed-1580-020000000000"/>
+   <id value="06696b8c-621b-11ee-8350-020000000000"/>
    <type value="searchset"/>
    <total value="18"/>
    <link>
@@ -21,8 +21,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag13 (urn:oid:2.16.840.1.113883.2.4.3.111.19.1), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag13 (urn:oid:2.16.840.1.113883.2.4.3.111.19.1), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -37,7 +36,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment13 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 16-06-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -60,15 +59,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment13"/>
-               <display value="Contact ID: MedMijHG-contactmoment13 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 16-06-2020"/>
             </encounter>
             <date value="2020-06-16T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -104,7 +109,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712de45-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:0669714f-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -134,8 +139,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag17 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag17 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -150,7 +154,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 11-06-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -173,15 +177,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment17"/>
-               <display value="Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 11-06-2020"/>
             </encounter>
             <date value="2020-06-11T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -217,7 +227,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712de62-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:0669716c-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -241,7 +251,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Nogmaals verwijzing Cesar</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712de6c-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06697176-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Nogmaals verwijzing Cesar"/>
                </entry>
                <entry>
@@ -271,8 +281,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag12 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag12 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -287,7 +296,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 07-05-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -310,15 +319,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment12"/>
-               <display value="Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 07-05-2020"/>
             </encounter>
             <date value="2020-05-07T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -354,7 +369,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d8a5-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698257-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -378,7 +393,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Bezoek brengen aan de tandarts, wellicht zit er daar iets.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d8af-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698261-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Bezoek brengen aan de tandarts, wellicht zit er daar iets."/>
                </entry>
                <entry>
@@ -408,8 +423,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag16 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag16 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -424,7 +438,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 02-05-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -447,15 +461,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment16"/>
-               <display value="Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 02-05-2020"/>
             </encounter>
             <date value="2020-05-02T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -491,7 +511,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d8c4-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698276-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -515,7 +535,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Patiënt geïnformeerd, ziet het nog even aan.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d8ce-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698280-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Patiënt geïnformeerd, ziet het nog even aan."/>
                </entry>
                <entry>
@@ -545,8 +565,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>HNP (thoracaal/lumbaal)</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag15 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag15 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -561,7 +580,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 27-04-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -584,15 +603,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment15"/>
-               <display value="Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 27-04-2020"/>
             </encounter>
             <date value="2020-04-27T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -628,7 +653,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">HNP</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d8e3-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698295-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - HNP"/>
                </entry>
                <entry>
@@ -652,7 +677,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Scan laten maken, afspraak gepland.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d8ed-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:0669829f-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Scan laten maken, afspraak gepland."/>
                </entry>
                <entry>
@@ -682,8 +707,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag14 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag14 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -698,7 +722,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 07-04-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -721,15 +745,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment14"/>
-               <display value="Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 07-04-2020"/>
             </encounter>
             <date value="2020-04-07T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -765,7 +795,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Lage rugpijn</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d902-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066982b4-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Lage rugpijn"/>
                </entry>
                <entry>
@@ -789,7 +819,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Cesar of Mensendieck. Verwijzing aangemaakt</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d90c-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066982be-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Cesar of Mensendieck. Verwijzing aangemaakt"/>
                </entry>
                <entry>
@@ -819,8 +849,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag11 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag11 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -835,7 +864,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 28-03-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -858,15 +887,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment11"/>
-               <display value="Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 28-03-2020"/>
             </encounter>
             <date value="2020-03-28T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -902,7 +937,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d921-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066982d3-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -926,7 +961,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Kweek van aanslag keel</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d92b-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066982dd-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Kweek van aanslag keel"/>
                </entry>
                <entry>
@@ -956,8 +991,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Maagpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag07 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag07 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -972,7 +1006,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment07 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 23-03-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -995,15 +1029,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment07"/>
-               <display value="Contact ID: MedMijHG-contactmoment07 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 23-03-2020"/>
             </encounter>
             <date value="2020-03-23T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1039,7 +1079,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Maag/duodenum problemen?</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d940-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066982f2-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Maag/duodenum problemen?"/>
                </entry>
                <entry>
@@ -1069,8 +1109,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag05 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag05 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1085,7 +1124,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 18-03-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -1108,15 +1147,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment05"/>
-               <display value="Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 18-03-2020"/>
             </encounter>
             <date value="2020-03-18T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1152,7 +1197,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Maag/duodenum problemen?</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d95d-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:0669830f-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Maag/duodenum problemen?"/>
                </entry>
                <entry>
@@ -1176,7 +1221,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Cesar of Mensendieck.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d967-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698319-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Cesar of Mensendieck."/>
                </entry>
                <entry>
@@ -1206,8 +1251,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag10 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag10 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1222,7 +1266,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 03-03-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -1245,15 +1289,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment10"/>
-               <display value="Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 03-03-2020"/>
             </encounter>
             <date value="2020-03-03T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1289,7 +1339,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d97c-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:0669832e-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -1313,7 +1363,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Afwachten, zn. Medicatie is nog beschikbaar</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d986-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698338-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Afwachten, zn. Medicatie is nog beschikbaar"/>
                </entry>
                <entry>
@@ -1343,8 +1393,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>lage rugpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag04 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag04 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1359,7 +1408,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment04 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 27-02-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -1382,15 +1431,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment04"/>
-               <display value="Contact ID: MedMijHG-contactmoment04 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 27-02-2020"/>
             </encounter>
             <date value="2020-02-27T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1426,7 +1481,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">lage rugpijn</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d99c-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:0669834e-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - lage rugpijn"/>
                </entry>
                <entry>
@@ -1456,8 +1511,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Keelpijn</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag06 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag06 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1472,7 +1526,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 28-01-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -1495,15 +1549,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment06"/>
-               <display value="Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 28-01-2020"/>
             </encounter>
             <date value="2020-01-28T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1539,7 +1599,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Keelpijn eci.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d9b8-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:0669836a-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Keelpijn eci."/>
                </entry>
                <entry>
@@ -1563,7 +1623,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Afwachten, zn. Pcm, tijdens feest paracod.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d9c2-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698374-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Afwachten, zn. Pcm, tijdens feest paracod."/>
                </entry>
                <entry>
@@ -1593,8 +1653,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Astma</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslagMMK (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslagMMK (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1609,7 +1668,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 18-01-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -1632,15 +1691,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmomentMMK"/>
-               <display value="Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 18-01-2020"/>
             </encounter>
             <date value="2020-01-18T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1676,7 +1741,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">astma</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d9d7-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698389-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - astma"/>
                </entry>
                <entry>
@@ -1700,7 +1765,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Salbutamol half uur voor het sporten.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d9e1-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698393-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Salbutamol half uur voor het sporten."/>
                </entry>
                <entry>
@@ -1730,8 +1795,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Tinea Pedis</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag09 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag09 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1746,7 +1810,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 08-01-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -1769,15 +1833,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment09"/>
-               <display value="Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 08-01-2020"/>
             </encounter>
             <date value="2020-01-08T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1813,7 +1883,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Mycose</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712d9f6-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066983a8-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Mycose"/>
                </entry>
                <entry>
@@ -1837,7 +1907,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Heeft nog canesten via drogist; 2x daags gebruiken.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712da00-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066983b2-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Heeft nog canesten via drogist; 2x daags gebruiken."/>
                </entry>
                <entry>
@@ -1867,8 +1937,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag J. XXX_Cevat</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag08 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag08 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -1883,7 +1952,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 03-01-2020</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -1906,15 +1975,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment08"/>
-               <display value="Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 03-01-2020"/>
             </encounter>
             <date value="2020-01-03T14:15:02+01:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -1941,7 +2016,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712da15-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066983c7-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl."/>
                </entry>
                <entry>
@@ -1965,7 +2040,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Echo</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712da18-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066983ca-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Echo"/>
                </entry>
                <entry>
@@ -1995,8 +2070,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag J. XXX_Cevat</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag03 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag03 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -2011,7 +2085,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment03 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 02-07-2019</td>
                         </tr>
                      </tbody>
                   </table>
@@ -2030,15 +2104,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment03"/>
-               <display value="Contact ID: MedMijHG-contactmoment03 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 02-07-2019"/>
             </encounter>
             <date value="2019-07-02T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2056,7 +2136,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Over paar weken RR thuis.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712da2c-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066983de-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Over paar weken RR thuis."/>
                </entry>
             </section>
@@ -2079,8 +2159,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Contactverslag J. XXX_Cevat</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag02 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag02 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -2095,7 +2174,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment02 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 12-06-2019</td>
                         </tr>
                      </tbody>
                   </table>
@@ -2114,15 +2193,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment02"/>
-               <display value="Contact ID: MedMijHG-contactmoment02 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 12-06-2019"/>
             </encounter>
             <date value="2019-06-12T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2140,7 +2225,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Na vakantie nogmaals.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712da40-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:066983f2-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Na vakantie nogmaals."/>
                </entry>
             </section>
@@ -2163,8 +2248,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <b>Boezemfibrilleren/-fladderen</b>
                   <table>
-                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag01 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
-                        </span>
+                     <caption>Samengestelde informatie. Subject: J. XXX_Cevat. Id: MedMijHG-contactverslag01 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: definitief<span style="display: block;">Auteur: Huisarts 1 || Gezondheidscentrum Aesculaap</span>
                      </caption>
                      <tbody>
                         <tr>
@@ -2179,7 +2263,7 @@
                         </tr>
                         <tr>
                            <th>Contact</th>
-                           <td>Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 23-05-2019</td>
                         </tr>
                         <tr>
                            <th>Gebeurtenis</th>
@@ -2202,15 +2286,21 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <encounter>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment01"/>
-               <display value="Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 23-05-2019"/>
             </encounter>
             <date value="2019-05-23T14:15:02+02:00"/>
             <author>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
+                  <valueReference>
+                     <reference value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
+                     <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
+                  </valueReference>
+               </extension>
                <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
                <display value="Huisarts 1"/>
             </author>
@@ -2246,7 +2336,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Ritmestoornis</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712da55-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698407-621b-11ee-8350-020000000000"/>
                   <display value="E: Evaluatie - Ritmestoornis"/>
                </entry>
                <entry>
@@ -2270,7 +2360,7 @@
                   <div xmlns="http://www.w3.org/1999/xhtml">Naar SEH.</div>
                </text>
                <entry>
-                  <reference value="urn:uuid:3712da5f-e371-11ed-1580-020000000000"/>
+                  <reference value="urn:uuid:06698411-621b-11ee-8350-020000000000"/>
                   <display value="P: Plan - Naar SEH."/>
                </entry>
                <entry>
@@ -2360,7 +2450,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2381,7 +2471,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2476,7 +2566,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2497,7 +2587,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2592,7 +2682,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2613,7 +2703,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2708,7 +2798,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2729,7 +2819,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2824,7 +2914,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2845,7 +2935,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -2940,7 +3030,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -2961,7 +3051,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3056,7 +3146,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3077,7 +3167,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3172,7 +3262,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3193,7 +3283,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3288,7 +3378,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3309,7 +3399,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3404,7 +3494,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3425,7 +3515,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3520,7 +3610,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3541,7 +3631,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3636,7 +3726,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3657,7 +3747,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3752,7 +3842,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3773,7 +3863,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3868,7 +3958,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -3889,7 +3979,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -3984,7 +4074,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -4005,7 +4095,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -4100,7 +4190,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <participant>
@@ -4114,7 +4204,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -4209,7 +4299,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <participant>
@@ -4223,7 +4313,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -4318,7 +4408,7 @@
                </coding>
             </type>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <episodeOfCare>
@@ -4339,7 +4429,7 @@
                <individual>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+                        <reference value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
                         <display value="Huisarts 1 || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -4362,7 +4452,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -4372,7 +4462,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">J. XXX_Cevat</span>, Man, 30 december 1985</div>
-                  <div>Knolweg 1003, 9999ZA STITSWERD, Nederland</div>
+                  <div>Knolweg 1003, 9999ZA STITSWERD, NL</div>
                </div>
             </text>
             <identifier>
@@ -4421,7 +4511,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999ZA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -4498,7 +4598,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712de37-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06697141-621b-11ee-8350-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -4553,7 +4653,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da7f-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698431-621b-11ee-8350-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -4608,7 +4708,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712de45-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669714f-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4618,11 +4718,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment13 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 16-06-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -4655,13 +4757,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment13"/>
-               <display value="Contact ID: MedMijHG-contactmoment13 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 16-06-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -4686,7 +4792,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712de62-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669716c-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4696,11 +4802,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 11-06-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -4733,13 +4841,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment17"/>
-               <display value="Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 11-06-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -4764,7 +4876,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712de6c-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06697176-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4774,11 +4886,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 11-06-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -4803,13 +4917,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment17"/>
-               <display value="Contact ID: MedMijHG-contactmoment17 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 11-06-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Nogmaals verwijzing Cesar"/>
          </Observation>
       </resource>
@@ -4818,7 +4936,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d8a5-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698257-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4828,11 +4946,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 07-05-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -4865,13 +4985,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment12"/>
-               <display value="Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 07-05-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -4896,7 +5020,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d8af-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698261-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4906,11 +5030,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 07-05-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -4935,13 +5061,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment12"/>
-               <display value="Contact ID: MedMijHG-contactmoment12 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 07-05-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Bezoek brengen aan de tandarts, wellicht zit er daar iets."/>
          </Observation>
       </resource>
@@ -4950,7 +5080,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d8c4-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698276-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -4960,11 +5090,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 02-05-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -4997,13 +5129,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment16"/>
-               <display value="Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 02-05-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -5028,7 +5164,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d8ce-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698280-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5038,11 +5174,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 02-05-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5067,13 +5205,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment16"/>
-               <display value="Contact ID: MedMijHG-contactmoment16 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 02-05-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Patiënt geïnformeerd, ziet het nog even aan."/>
          </Observation>
       </resource>
@@ -5082,7 +5224,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d8e3-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698295-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5092,11 +5234,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 27-04-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5129,13 +5273,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment15"/>
-               <display value="Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 27-04-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="HNP"/>
             <component>
                <code>
@@ -5160,7 +5308,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d8ed-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669829f-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5170,11 +5318,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 27-04-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5199,13 +5349,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment15"/>
-               <display value="Contact ID: MedMijHG-contactmoment15 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 27-04-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Scan laten maken, afspraak gepland."/>
          </Observation>
       </resource>
@@ -5214,7 +5368,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d902-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066982b4-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5224,11 +5378,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 07-04-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5261,13 +5417,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment14"/>
-               <display value="Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 07-04-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Lage rugpijn"/>
             <component>
                <code>
@@ -5292,7 +5452,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d90c-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066982be-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5302,11 +5462,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 07-04-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5331,13 +5493,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment14"/>
-               <display value="Contact ID: MedMijHG-contactmoment14 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 07-04-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Cesar of Mensendieck. Verwijzing aangemaakt"/>
          </Observation>
       </resource>
@@ -5346,7 +5512,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d921-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066982d3-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5356,11 +5522,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 28-03-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5393,13 +5561,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment11"/>
-               <display value="Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 28-03-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -5424,7 +5596,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d92b-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066982dd-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5434,11 +5606,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 28-03-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5463,13 +5637,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment11"/>
-               <display value="Contact ID: MedMijHG-contactmoment11 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 28-03-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Kweek van aanslag keel"/>
          </Observation>
       </resource>
@@ -5478,7 +5656,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d940-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066982f2-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5488,11 +5666,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment07 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 23-03-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5525,13 +5705,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment07"/>
-               <display value="Contact ID: MedMijHG-contactmoment07 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 23-03-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Maag/duodenum problemen?"/>
             <component>
                <code>
@@ -5556,7 +5740,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d95d-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669830f-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5566,11 +5750,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 18-03-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5603,13 +5789,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment05"/>
-               <display value="Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 18-03-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Maag/duodenum problemen?"/>
             <component>
                <code>
@@ -5634,7 +5824,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d967-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698319-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5644,11 +5834,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 18-03-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5673,13 +5865,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment05"/>
-               <display value="Contact ID: MedMijHG-contactmoment05 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 18-03-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Cesar of Mensendieck."/>
          </Observation>
       </resource>
@@ -5688,7 +5884,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d97c-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669832e-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5698,11 +5894,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 03-03-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5735,13 +5933,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment10"/>
-               <display value="Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 03-03-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -5766,7 +5968,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d986-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698338-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5776,11 +5978,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 03-03-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5805,13 +6009,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment10"/>
-               <display value="Contact ID: MedMijHG-contactmoment10 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 03-03-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Afwachten, zn. Medicatie is nog beschikbaar"/>
          </Observation>
       </resource>
@@ -5820,7 +6028,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d99c-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669834e-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5830,11 +6038,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment04 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 27-02-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5867,13 +6077,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment04"/>
-               <display value="Contact ID: MedMijHG-contactmoment04 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 27-02-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="lage rugpijn"/>
             <component>
                <code>
@@ -5898,7 +6112,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d9b8-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:0669836a-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5908,11 +6122,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 28-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -5945,13 +6161,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment06"/>
-               <display value="Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 28-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Keelpijn eci."/>
             <component>
                <code>
@@ -5976,7 +6196,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d9c2-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698374-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -5986,11 +6206,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 28-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6015,13 +6237,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment06"/>
-               <display value="Contact ID: MedMijHG-contactmoment06 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 28-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Afwachten, zn. Pcm, tijdens feest paracod."/>
          </Observation>
       </resource>
@@ -6030,7 +6256,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d9d7-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698389-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6040,11 +6266,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 18-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6077,13 +6305,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmomentMMK"/>
-               <display value="Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 18-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="astma"/>
             <component>
                <code>
@@ -6108,7 +6340,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d9e1-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698393-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6118,11 +6350,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 18-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6147,13 +6381,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmomentMMK"/>
-               <display value="Contact ID: MedMijHG-contactmomentMMK 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 18-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Salbutamol half uur voor het sporten."/>
          </Observation>
       </resource>
@@ -6162,7 +6400,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712d9f6-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066983a8-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6172,11 +6410,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 08-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6209,13 +6449,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment09"/>
-               <display value="Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 08-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Mycose"/>
             <component>
                <code>
@@ -6240,7 +6484,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da00-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066983b2-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6250,11 +6494,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 08-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6279,13 +6525,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment09"/>
-               <display value="Contact ID: MedMijHG-contactmoment09 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 08-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Heeft nog canesten via drogist; 2x daags gebruiken."/>
          </Observation>
       </resource>
@@ -6294,7 +6544,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da15-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066983c7-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6304,11 +6554,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 03-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6333,13 +6585,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment08"/>
-               <display value="Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 03-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Onder mandibula re. glad weinig mobile zwelling, lijkt speekselkl."/>
          </Observation>
       </resource>
@@ -6348,7 +6604,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da18-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066983ca-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6358,11 +6614,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 03-01-2020</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6387,13 +6645,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment08"/>
-               <display value="Contact ID: MedMijHG-contactmoment08 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 03-01-2020"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Echo"/>
          </Observation>
       </resource>
@@ -6402,7 +6664,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da2c-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066983de-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6412,11 +6674,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment03 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 02-07-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6441,13 +6705,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment03"/>
-               <display value="Contact ID: MedMijHG-contactmoment03 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 02-07-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Over paar weken RR thuis."/>
          </Observation>
       </resource>
@@ -6456,7 +6724,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da40-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:066983f2-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6466,11 +6734,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment02 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 12-06-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6495,13 +6765,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment02"/>
-               <display value="Contact ID: MedMijHG-contactmoment02 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 12-06-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Na vakantie nogmaals."/>
          </Observation>
       </resource>
@@ -6510,7 +6784,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da55-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698407-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6520,11 +6794,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 23-05-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6557,13 +6833,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment01"/>
-               <display value="Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 23-05-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Ritmestoornis"/>
             <component>
                <code>
@@ -6588,7 +6868,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3712da5f-e371-11ed-1580-020000000000"/>
+      <fullUrl value="urn:uuid:06698411-621b-11ee-8350-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -6598,11 +6878,13 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief</caption>
+                     <caption>Observatie/bepaling. Subject: J. XXX_Cevat. Status: definitief<span style="display: block;">Uitvoerende: <a href="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431">Huisarts 1</a>
+                        </span>
+                     </caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
-                           <td>Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1</td>
+                           <td>Contact: consult met Huisarts 1 op 23-05-2019</td>
                         </tr>
                         <tr>
                            <th>Code</th>
@@ -6627,13 +6909,17 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3712de24-e371-11ed-1580-020000000000"/>
+               <reference value="urn:uuid:0669712e-621b-11ee-8350-020000000000"/>
                <display value="J. XXX_Cevat"/>
             </subject>
             <context>
                <reference value="Encounter/2.16.840.1.113883.2.4.3.111.19.1-MedMijHG-contactmoment01"/>
-               <display value="Contact ID: MedMijHG-contactmoment01 2.16.840.1.113883.2.4.3.111.19.1"/>
+               <display value="Contact: consult met Huisarts 1 op 23-05-2019"/>
             </context>
+            <performer>
+               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900016431"/>
+               <display value="Huisarts 1"/>
+            </performer>
             <valueString value="Naar SEH."/>
          </Observation>
       </resource>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/diagnostische_bepalingen_bundle_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/diagnostische_bepalingen_bundle_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="3744e14c-e371-11ed-8748-020000000000"/>
+   <id value="06981234-621b-11ee-7088-020000000000"/>
    <type value="searchset"/>
    <total value="29"/>
    <link>
@@ -21,8 +21,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21120 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -44,10 +43,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21120"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -63,7 +58,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -75,20 +70,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueCodeableConcept>
                <coding>
                   <system value="https://referentiemodel.nhg.org/tabellen/nhg-tabel-45-diagnostische-bepalingen#resultaten"/>
@@ -115,8 +100,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21121 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -141,10 +125,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21121"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -160,7 +140,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -172,20 +152,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueQuantity>
                <value value="97"/>
                <unit value="%"/>
@@ -232,8 +202,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21123 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -255,10 +224,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21123"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -274,7 +239,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -286,20 +251,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-03"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueCodeableConcept>
                <coding>
                   <system value="https://referentiemodel.nhg.org/tabellen/nhg-tabel-45-diagnostische-bepalingen#resultaten"/>
@@ -326,8 +281,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21124 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -352,10 +306,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21124"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -371,7 +321,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -383,20 +333,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-05"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueQuantity>
                <value value="4.5"/>
                <unit value="mmol/L"/>
@@ -443,8 +383,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21132 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -469,10 +408,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21132"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -488,7 +423,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -500,20 +435,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueQuantity>
                <value value="95"/>
                <unit value="%"/>
@@ -621,7 +546,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -635,7 +560,7 @@
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -737,14 +662,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -846,14 +771,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -949,14 +874,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1023,14 +948,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2017-07-09"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1100,14 +1025,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1205,14 +1130,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1300,14 +1225,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1374,14 +1299,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1447,14 +1372,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1525,14 +1450,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1627,14 +1552,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1727,14 +1652,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1797,14 +1722,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1871,14 +1796,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -1946,14 +1871,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2025,14 +1950,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-03"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2127,14 +2052,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2232,14 +2157,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2330,14 +2255,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2426,14 +2351,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2500,14 +2425,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2575,14 +2500,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2651,14 +2576,14 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+               <reference value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
             <performer>
                <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                   <valueReference>
-                     <reference value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+                     <reference value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
                      <display value="Responsible Party"/>
                   </valueReference>
                </extension>
@@ -2679,7 +2604,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3744f0d0-e371-11ed-8748-020000000000"/>
+      <fullUrl value="urn:uuid:069821b8-621b-11ee-7088-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -2689,7 +2614,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -2755,7 +2680,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -2821,7 +2756,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:3744f0e5-e371-11ed-8748-020000000000"/>
+      <fullUrl value="urn:uuid:069821cd-621b-11ee-7088-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/episodes_REPC_EX990111NL_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/episodes_REPC_EX990111NL_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="36cd230a-e371-11ed-6469-020000000000"/>
+   <id value="061d62b4-621b-11ee-6343-020000000000"/>
    <type value="searchset"/>
    <total value="1"/>
    <link>
@@ -9,9 +9,10 @@
       <url value="http://dummy.nictiz.nl/dummyquery"/>
    </link>
    <entry>
-      <fullUrl value="urn:uuid:adbfb4cf-1736-41ff-9f55-140e008aa498"/>
+      <fullUrl value="https://example.org/fhir/EpisodeOfCare/adbfb4cf-1736-41ff-9f55-140e008aa498"/>
       <resource>
          <EpisodeOfCare>
+            <id value="adbfb4cf-1736-41ff-9f55-140e008aa498"/>
             <meta>
                <profile value="http://fhir.nl/fhir/StructureDefinition/nl-core-episodeofcare"/>
             </meta>
@@ -40,7 +41,9 @@
                         </tr>
                         <tr>
                            <th>Diagnose</th>
-                           <td>Emfyseem/COPD</td>
+                           <td>
+                              <a href="https://example.org/fhir/Condition/c4543900-ee6f-44c6-ab71-315b29da078e">Emfyseem/COPD</a>
+                           </td>
                         </tr>
                      </tbody>
                   </table>
@@ -73,12 +76,12 @@
             </type>
             <diagnosis>
                <condition>
-                  <reference value="urn:uuid:c4543900-ee6f-44c6-ab71-315b29da078e"/>
+                  <reference value="https://example.org/fhir/Condition/c4543900-ee6f-44c6-ab71-315b29da078e"/>
                   <display value="Emfyseem/COPD"/>
                </condition>
             </diagnosis>
             <patient>
-               <reference value="urn:uuid:36cd328e-e371-11ed-6469-020000000000"/>
+               <reference value="urn:uuid:061d7238-621b-11ee-6343-020000000000"/>
                <display value="Joris Hansman"/>
             </patient>
             <managingOrganization>
@@ -95,7 +98,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36cd328e-e371-11ed-6469-020000000000"/>
+      <fullUrl value="urn:uuid:061d7238-621b-11ee-6343-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -181,9 +184,10 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:c4543900-ee6f-44c6-ab71-315b29da078e"/>
+      <fullUrl value="https://example.org/fhir/Condition/c4543900-ee6f-44c6-ab71-315b29da078e"/>
       <resource>
          <Condition>
+            <id value="c4543900-ee6f-44c6-ab71-315b29da078e"/>
             <meta>
                <profile value="http://nictiz.nl/fhir/StructureDefinition/zib-Problem"/>
             </meta>
@@ -237,7 +241,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36cd328e-e371-11ed-6469-020000000000"/>
+               <reference value="urn:uuid:061d7238-621b-11ee-6343-020000000000"/>
                <display value="Joris Hansman"/>
             </subject>
             <onsetPeriod>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/episodes_REPC_EX990111NL_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/episodes_REPC_EX990111NL_02.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="36cf17d2-e371-11ed-1454-020000000000"/>
+   <id value="061f6f00-621b-11ee-6481-020000000000"/>
    <type value="searchset"/>
    <total value="1"/>
    <link>
@@ -74,12 +74,12 @@
             </type>
             <diagnosis>
                <condition>
-                  <reference value="urn:uuid:36cf237a-e371-11ed-1454-020000000000"/>
+                  <reference value="urn:uuid:061f7b02-621b-11ee-6481-020000000000"/>
                   <display value="Tinea Pedis"/>
                </condition>
             </diagnosis>
             <patient>
-               <reference value="urn:uuid:36cf2364-e371-11ed-1454-020000000000"/>
+               <reference value="urn:uuid:061f7aec-621b-11ee-6481-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </patient>
             <managingOrganization>
@@ -96,7 +96,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36cf2364-e371-11ed-1454-020000000000"/>
+      <fullUrl value="urn:uuid:061f7aec-621b-11ee-6481-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -106,7 +106,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">H. XXX_Mulders</span>, Man, 30 december 1985</div>
-                  <div>Knolweg 1003, 9999ZA STITSWERD, Nederland</div>
+                  <div>Knolweg 1003, 9999ZA STITSWERD, NL</div>
                </div>
             </text>
             <identifier>
@@ -155,7 +155,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999ZA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -197,7 +207,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36cf237a-e371-11ed-1454-020000000000"/>
+      <fullUrl value="urn:uuid:061f7b02-621b-11ee-6481-020000000000"/>
       <resource>
          <Condition>
             <meta>
@@ -253,7 +263,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36cf2364-e371-11ed-1454-020000000000"/>
+               <reference value="urn:uuid:061f7aec-621b-11ee-6481-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <onsetPeriod>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/episodes_bundle_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/episodes_bundle_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="36d01f06-e371-11ed-1118-020000000000"/>
+   <id value="06207d6e-621b-11ee-6809-020000000000"/>
    <type value="searchset"/>
    <total value="4"/>
    <link>
@@ -20,7 +20,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Zorgepisode. Patiënt: urn:uuid:36d0286a-e371-11ed-1118-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
+                     <caption>Zorgepisode. Patiënt: urn:uuid:0620872c-621b-11ee-6809-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
                      <tbody>
                         <tr>
                            <th>Type</th>
@@ -81,7 +81,7 @@
                </condition>
             </diagnosis>
             <patient>
-               <reference value="urn:uuid:36d0286a-e371-11ed-1118-020000000000"/>
+               <reference value="urn:uuid:0620872c-621b-11ee-6809-020000000000"/>
             </patient>
             <managingOrganization>
                <reference value="https://example.org/fhir/Organization/2.16.528.1.1007.3.3-00002727"/>
@@ -108,7 +108,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Zorgepisode. Patiënt: urn:uuid:36d0286a-e371-11ed-1118-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
+                     <caption>Zorgepisode. Patiënt: urn:uuid:0620872c-621b-11ee-6809-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
                      <tbody>
                         <tr>
                            <th>Type</th>
@@ -169,7 +169,7 @@
                </condition>
             </diagnosis>
             <patient>
-               <reference value="urn:uuid:36d0286a-e371-11ed-1118-020000000000"/>
+               <reference value="urn:uuid:0620872c-621b-11ee-6809-020000000000"/>
             </patient>
             <managingOrganization>
                <reference value="https://example.org/fhir/Organization/2.16.528.1.1007.3.3-00002727"/>
@@ -196,7 +196,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Zorgepisode. Patiënt: urn:uuid:36d0286a-e371-11ed-1118-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
+                     <caption>Zorgepisode. Patiënt: urn:uuid:0620872c-621b-11ee-6809-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
                      <tbody>
                         <tr>
                            <th>Type</th>
@@ -257,7 +257,7 @@
                </condition>
             </diagnosis>
             <patient>
-               <reference value="urn:uuid:36d0286a-e371-11ed-1118-020000000000"/>
+               <reference value="urn:uuid:0620872c-621b-11ee-6809-020000000000"/>
             </patient>
             <managingOrganization>
                <reference value="https://example.org/fhir/Organization/2.16.528.1.1007.3.3-00003131"/>
@@ -284,7 +284,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Zorgepisode. Patiënt: urn:uuid:36d0286a-e371-11ed-1118-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
+                     <caption>Zorgepisode. Patiënt: urn:uuid:0620872c-621b-11ee-6809-020000000000. Id: hc657498ft562.9895 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Status: actief</caption>
                      <tbody>
                         <tr>
                            <th>Type</th>
@@ -345,7 +345,7 @@
                </condition>
             </diagnosis>
             <patient>
-               <reference value="urn:uuid:36d0286a-e371-11ed-1118-020000000000"/>
+               <reference value="urn:uuid:0620872c-621b-11ee-6809-020000000000"/>
             </patient>
             <managingOrganization>
                <reference value="https://example.org/fhir/Organization/2.16.528.1.1007.3.3-00003131"/>
@@ -361,7 +361,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:36d0286a-e371-11ed-1118-020000000000"/>
+      <fullUrl value="urn:uuid:0620872c-621b-11ee-6809-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -479,7 +479,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Aandoening. Subject: urn:uuid:36d0286a-e371-11ed-1118-020000000000. Id: po3564b7c0-2111 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Categorie: <span title="Diagnosis (282291009 - SNOMED CT)">Diagnosis</span>, Status: actief</caption>
+                     <caption>Aandoening. Subject: urn:uuid:0620872c-621b-11ee-6809-020000000000. Id: po3564b7c0-2111 (urn:oid:2.16.528.1.1007.3.3.765332.1.12), Categorie: <span title="Diagnosis (282291009 - SNOMED CT)">Diagnosis</span>, Status: actief</caption>
                      <tbody>
                         <tr>
                            <th>Code</th>
@@ -525,7 +525,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:36d0286a-e371-11ed-1118-020000000000"/>
+               <reference value="urn:uuid:0620872c-621b-11ee-6809-020000000000"/>
             </subject>
             <onsetPeriod>
                <start value="2007-04-02"/>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/labbepalingen_POLB_IN364001NL03_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/labbepalingen_POLB_IN364001NL03_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="376da848-e371-11ed-7868-020000000000"/>
+   <id value="06c30d22-621b-11ee-2052-020000000000"/>
    <type value="searchset"/>
    <total value="7"/>
    <link>
@@ -21,8 +21,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21120 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Context</th>
@@ -48,10 +47,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21120"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -67,7 +62,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -79,7 +74,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+               <reference value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -90,16 +85,6 @@
                <display value="Contact ID: 996624 2.16.840.1.113883.2.4.6.6.90000258.4.1"/>
             </context>
             <effectiveDateTime value="2019-01-30"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueCodeableConcept>
                <coding>
                   <system value="https://referentiemodel.nhg.org/tabellen/nhg-tabel-45-diagnostische-bepalingen#resultaten"/>
@@ -126,8 +111,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21121 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -152,10 +136,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21121"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -171,7 +151,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -183,20 +163,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+               <reference value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-01-30"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueQuantity>
                <value value="97"/>
                <unit value="%"/>
@@ -243,8 +213,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21123 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -266,10 +235,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21123"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -285,7 +250,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -297,20 +262,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+               <reference value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-03"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueCodeableConcept>
                <coding>
                   <system value="https://referentiemodel.nhg.org/tabellen/nhg-tabel-45-diagnostische-bepalingen#resultaten"/>
@@ -337,8 +292,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21124 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -363,10 +317,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21124"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -382,7 +332,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -394,20 +344,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+               <reference value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-05"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueQuantity>
                <value value="4.5"/>
                <unit value="mmol/L"/>
@@ -454,8 +394,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21132 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -480,10 +419,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21132"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -499,7 +434,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -511,20 +446,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+               <reference value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueQuantity>
                <value value="95"/>
                <unit value="%"/>
@@ -571,8 +496,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21132 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -601,10 +525,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21132"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -620,7 +540,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -632,20 +552,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+               <reference value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-02"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueQuantity>
                <value value="90"/>
                <unit value="%"/>
@@ -699,8 +609,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <table>
-                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Id: 21123 (urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7), Categorie: <span title="Laboratory test finding (49581000146104 - SNOMED CT)">Laboratory test finding</span>, Status: definitief<span style="display: block;">Uitvoerende: Responsible Party</span>
-                     </caption>
+                     <caption>Observatie/bepaling. Subject: E. XXX_Zegers. Categorie: <span title="bevinding betreffende laboratoriumonderzoek (49581000146104 - SNOMED CT)">bevinding betreffende laboratoriumonderzoek</span>, Status: definitief</caption>
                      <tbody>
                         <tr>
                            <th>Bepalingdatum/tijd</th>
@@ -720,10 +629,6 @@
                   </table>
                </div>
             </text>
-            <identifier>
-               <system value="urn:oid:2.16.840.1.113883.2.4.6.6.90000258.4.7"/>
-               <value value="21123"/>
-            </identifier>
             <status value="final">
                <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
                   <valueCodeableConcept>
@@ -739,7 +644,7 @@
                <coding>
                   <system value="http://snomed.info/sct"/>
                   <code value="49581000146104"/>
-                  <display value="Laboratory test finding"/>
+                  <display value="bevinding betreffende laboratoriumonderzoek"/>
                </coding>
             </category>
             <code>
@@ -751,20 +656,10 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+               <reference value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <effectiveDateTime value="2019-02-03"/>
-            <performer>
-               <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
-                  <valueReference>
-                     <reference value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
-                     <display value="Responsible Party"/>
-                  </valueReference>
-               </extension>
-               <reference value="https://example.org/fhir/Practitioner/2.16.528.1.1007.3.1-900014718"/>
-               <display value="Responsible Party"/>
-            </performer>
             <valueBoolean value="true"/>
          </Observation>
       </resource>
@@ -773,7 +668,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:376db7cc-e371-11ed-7868-020000000000"/>
+      <fullUrl value="urn:uuid:06c31ca6-621b-11ee-2052-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -783,7 +678,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -849,7 +744,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -882,7 +787,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:376db7c9-e371-11ed-7868-020000000000"/>
+      <fullUrl value="urn:uuid:06c31ca3-621b-11ee-2052-020000000000"/>
       <resource>
          <Organization>
             <meta>
@@ -910,7 +815,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:376db7e3-e371-11ed-7868-020000000000"/>
+      <fullUrl value="urn:uuid:06c31cbd-621b-11ee-2052-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_Kwalificatie.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_Kwalificatie.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="38077090-e371-11ed-6779-020000000000"/>
+   <id value="075a20b8-621b-11ee-5414-020000000000"/>
    <type value="searchset"/>
    <total value="7"/>
    <link>
@@ -118,7 +118,7 @@
                <display value="PANTOPRAZOL TABLET MSR 40MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -133,7 +133,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+                        <reference value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Tést Zorginstelling 04"/>
                      </valueReference>
                   </extension>
@@ -150,7 +150,7 @@
                <text value="Volgens afspraak"/>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:38078099-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a30c1-621b-11ee-5414-020000000000"/>
                <display value="Maagpijn"/>
             </reasonReference>
             <dosageInstruction>
@@ -291,7 +291,7 @@
                <display value="PARACETAMOL TABLET  500MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -306,7 +306,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+                        <reference value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Tést Zorginstelling 04"/>
                      </valueReference>
                   </extension>
@@ -323,7 +323,7 @@
                <text value="Volgens afspraak"/>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:380782be-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a32e6-621b-11ee-5414-020000000000"/>
                <display value="Emfyseem/COPD"/>
             </reasonReference>
             <dosageInstruction>
@@ -474,7 +474,7 @@
                <display value="FLUTICASON INHALATIEPOEDER 250UG/DO 60DO DISKUS"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -489,7 +489,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+                        <reference value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Tést Zorginstelling 04"/>
                      </valueReference>
                   </extension>
@@ -506,7 +506,7 @@
                <text value="Volgens afspraak"/>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:380782be-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a32e6-621b-11ee-5414-020000000000"/>
                <display value="Emfyseem/COPD"/>
             </reasonReference>
             <dosageInstruction>
@@ -643,7 +643,7 @@
                <display value="AMOXICILLINE/CLAVULAANZUUR TABLET 500/125MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -658,7 +658,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+                        <reference value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Tést Zorginstelling 04"/>
                      </valueReference>
                   </extension>
@@ -675,7 +675,7 @@
                <text value="Volgens afspraak"/>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:380782be-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a32e6-621b-11ee-5414-020000000000"/>
                <display value="Emfyseem/COPD"/>
             </reasonReference>
             <dosageInstruction>
@@ -811,7 +811,7 @@
                <display value="SALBUTAMOL INHALATIEPOEDER 100UG/DO PATR 200DO"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -826,7 +826,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+                        <reference value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Tést Zorginstelling 04"/>
                      </valueReference>
                   </extension>
@@ -843,7 +843,7 @@
                <text value="Volgens afspraak"/>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:380782be-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a32e6-621b-11ee-5414-020000000000"/>
                <display value="Emfyseem/COPD"/>
             </reasonReference>
             <dosageInstruction>
@@ -973,7 +973,7 @@
                <display value="DESLORATADINE TABLET 5MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -988,7 +988,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+                        <reference value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Tést Zorginstelling 04"/>
                      </valueReference>
                   </extension>
@@ -1005,7 +1005,7 @@
                <text value="Volgens afspraak"/>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:38078388-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a33b0-621b-11ee-5414-020000000000"/>
                <display value="Hooikoorts/allergische rhinitis"/>
             </reasonReference>
             <dosageInstruction>
@@ -1142,7 +1142,7 @@
                <display value="CARBASALAATCALCIUM BRUISTABLET 100MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
             <context>
@@ -1157,7 +1157,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+                        <reference value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Tést Zorginstelling 04"/>
                      </valueReference>
                   </extension>
@@ -1174,7 +1174,7 @@
                <text value="Volgens afspraak"/>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:380783b9-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a33e1-621b-11ee-5414-020000000000"/>
                <display value="Boezemfibrilleren/-fladderen"/>
             </reasonReference>
             <dosageInstruction>
@@ -1216,7 +1216,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+      <fullUrl value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -1228,7 +1228,7 @@
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">E. XXX_Zegers</span>, Vrouw, 2 augustus 1964</div>
                   <div>
                      <a href="tel:+31190531770">+31190531770</a> (Tel Privé)</div>
-                  <div>Knolweg 1001, 9999XX STITSWERD, Nederland (officieel Privé (hoofd) Bezoek)</div>
+                  <div>Knolweg 1001, 9999XX STITSWERD, NL (officieel Privé (hoofd) Bezoek)</div>
                </div>
             </text>
             <identifier>
@@ -1309,7 +1309,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999XX"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -1330,6 +1340,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 900013866 (UZI-NR-PERS), <span title="Naamsamenstelling: Onbekend">Huisarts 1</span>
                   </div>
+                  <div>Valkendael 45, 6245HK Maastricht, NL (WP)</div>
                </div>
             </text>
             <identifier>
@@ -1346,6 +1357,36 @@
                   </extension>
                </family>
             </name>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation-AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Valkendael 45">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Valkendael 45"/>
+                  </extension>
+               </line>
+               <city value="Maastricht"/>
+               <postalCode value="6245HK"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
+            </address>
          </Practitioner>
       </resource>
       <search>
@@ -1372,7 +1413,7 @@
                         </tr>
                         <tr>
                            <th>Adres</th>
-                           <td>Valkendael 45, 6245HK Maastricht, Nederland (WP)</td>
+                           <td>Valkendael 45, 6245HK Maastricht, NL (WP)</td>
                         </tr>
                      </tbody>
                   </table>
@@ -1401,7 +1442,17 @@
                </line>
                <city value="Maastricht"/>
                <postalCode value="6245HK"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Organization>
       </resource>
@@ -1410,7 +1461,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:38078086-e371-11ed-6779-020000000000"/>
+      <fullUrl value="urn:uuid:075a30ae-621b-11ee-5414-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -1759,7 +1810,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:38078099-e371-11ed-6779-020000000000"/>
+      <fullUrl value="urn:uuid:075a30c1-621b-11ee-5414-020000000000"/>
       <resource>
          <Condition>
             <meta>
@@ -1790,7 +1841,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
          </Condition>
@@ -1800,7 +1851,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380782be-e371-11ed-6779-020000000000"/>
+      <fullUrl value="urn:uuid:075a32e6-621b-11ee-5414-020000000000"/>
       <resource>
          <Condition>
             <meta>
@@ -1831,7 +1882,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
          </Condition>
@@ -1841,7 +1892,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:38078388-e371-11ed-6779-020000000000"/>
+      <fullUrl value="urn:uuid:075a33b0-621b-11ee-5414-020000000000"/>
       <resource>
          <Condition>
             <meta>
@@ -1872,7 +1923,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
          </Condition>
@@ -1882,7 +1933,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380783b9-e371-11ed-6779-020000000000"/>
+      <fullUrl value="urn:uuid:075a33e1-621b-11ee-5414-020000000000"/>
       <resource>
          <Condition>
             <meta>
@@ -1913,7 +1964,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:38077094-e371-11ed-6779-020000000000"/>
+               <reference value="urn:uuid:075a20bc-621b-11ee-5414-020000000000"/>
                <display value="E. XXX_Zegers"/>
             </subject>
          </Condition>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_QUMA_IN991203NL02_01.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_QUMA_IN991203NL02_01.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="380c0fa6-e371-11ed-1201-020000000000"/>
+   <id value="075de91e-621b-11ee-6030-020000000000"/>
    <type value="searchset"/>
    <total value="1"/>
    <link>
@@ -89,7 +89,7 @@
                <display value="Metoclopramide zetpil 20mg"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:380c0faa-e371-11ed-1201-020000000000"/>
+               <reference value="urn:uuid:075de922-621b-11ee-6030-020000000000"/>
                <display value="Joris Hansman"/>
             </subject>
             <authoredOn value="2016-06-23T16:54:23+02:00"/>
@@ -97,7 +97,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:380c103d-e371-11ed-1201-020000000000"/>
+                        <reference value="urn:uuid:075dea0f-621b-11ee-6030-020000000000"/>
                         <display value="Dr Jansen || Internist || Ziekenhuis zus en zo"/>
                      </valueReference>
                   </extension>
@@ -143,7 +143,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380c0faa-e371-11ed-1201-020000000000"/>
+      <fullUrl value="urn:uuid:075de922-621b-11ee-6030-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -208,6 +208,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 012345678 (UZI-NR-PERS), Dr Jansen</div>
+                  <div>Dorpsstraat 10, 1111AA Ons Dorp (WP)</div>
                </div>
             </text>
             <identifier>
@@ -217,6 +218,28 @@
             <name>
                <text value="Dr Jansen"/>
             </name>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation-AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Dorpsstraat 10">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Dorpsstraat"/>
+                  </extension>
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                     <valueString value="10"/>
+                  </extension>
+               </line>
+               <city value="Ons Dorp"/>
+               <postalCode value="1111AA"/>
+            </address>
          </Practitioner>
       </resource>
       <search>
@@ -283,7 +306,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380c103d-e371-11ed-1201-020000000000"/>
+      <fullUrl value="urn:uuid:075dea0f-621b-11ee-6030-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_QUMA_IN991203NL02_02.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_QUMA_IN991203NL02_02.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="380cc626-e371-11ed-1670-020000000000"/>
+   <id value="075e9378-621b-11ee-8836-020000000000"/>
    <type value="searchset"/>
    <total value="1"/>
    <link>
@@ -99,7 +99,7 @@
                <display value="METFORMINE TABLET 1000MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:380cc62a-e371-11ed-1670-020000000000"/>
+               <reference value="urn:uuid:075e937c-621b-11ee-8836-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
             <context>
@@ -114,7 +114,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:380cc751-e371-11ed-1670-020000000000"/>
+                        <reference value="urn:uuid:075e9665-621b-11ee-8836-020000000000"/>
                         <display value="Huisarts 1 || Huisarts || Gezondheidscentrum Aesculaap"/>
                      </valueReference>
                   </extension>
@@ -123,7 +123,7 @@
                </agent>
             </requester>
             <reasonReference>
-               <reference value="urn:uuid:380cc760-e371-11ed-1670-020000000000"/>
+               <reference value="urn:uuid:075e9674-621b-11ee-8836-020000000000"/>
                <display value="Diabetes Mellitus type 2"/>
             </reasonReference>
             <dosageInstruction>
@@ -157,7 +157,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380cc62a-e371-11ed-1670-020000000000"/>
+      <fullUrl value="urn:uuid:075e937c-621b-11ee-8836-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -167,7 +167,7 @@
                <status value="extensions"/>
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id <i>afgeschermd (ontbrekend gegeven)</i> (BSN), <span title="Naamsamenstelling: Eigennaam">H. XXX_Mulders</span>, Man, 30 december 1985</div>
-                  <div>Knolweg 1003, 9999ZA STITSWERD, Nederland</div>
+                  <div>Knolweg 1003, 9999ZA STITSWERD, NL</div>
                </div>
             </text>
             <identifier>
@@ -216,7 +216,17 @@
                </line>
                <city value="STITSWERD"/>
                <postalCode value="9999ZA"/>
-               <country value="Nederland"/>
+               <country value="NL">
+                  <extension url="http://nictiz.nl/fhir/StructureDefinition/code-specification">
+                     <valueCodeableConcept>
+                        <coding>
+                           <system value="urn:iso:std:iso:3166"/>
+                           <code value="NL"/>
+                           <display value="Nederland"/>
+                        </coding>
+                     </valueCodeableConcept>
+                  </extension>
+               </country>
             </address>
          </Patient>
       </resource>
@@ -237,6 +247,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 900016431 (UZI-NR-PERS), <span title="Naamsamenstelling: Onbekend">Huisarts 1</span>
                   </div>
+                  <div>Maastricht (WP)</div>
                </div>
             </text>
             <identifier>
@@ -253,6 +264,19 @@
                   </extension>
                </family>
             </name>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation-AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <city value="Maastricht"/>
+            </address>
          </Practitioner>
       </resource>
       <search>
@@ -310,7 +334,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380cc751-e371-11ed-1670-020000000000"/>
+      <fullUrl value="urn:uuid:075e9665-621b-11ee-8836-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -407,7 +431,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380cc760-e371-11ed-1670-020000000000"/>
+      <fullUrl value="urn:uuid:075e9674-621b-11ee-8836-020000000000"/>
       <resource>
          <Condition>
             <meta>
@@ -438,7 +462,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:380cc62a-e371-11ed-1670-020000000000"/>
+               <reference value="urn:uuid:075e937c-621b-11ee-8836-020000000000"/>
                <display value="H. XXX_Mulders"/>
             </subject>
          </Condition>

--- a/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_XXX_Amaya-907.xml
+++ b/ada_2_fhir/ketenzorg/3.0.2/beschikbaarstellen/fhir_instance/medicatieafspraken_XXX_Amaya-907.xml
@@ -1,7 +1,7 @@
 <?xml-model href="http://hl7.org/fhir/STU3/bundle.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><Bundle xmlns="http://hl7.org/fhir"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://hl7.org/fhir http://hl7.org/fhir/STU3/fhir-all.xsd">
-   <id value="380dc47c-e371-11ed-2910-020000000000"/>
+   <id value="075f8ba2-621b-11ee-1177-020000000000"/>
    <type value="searchset"/>
    <total value="5"/>
    <link>
@@ -9,7 +9,7 @@
       <url value="http://dummy.nictiz.nl/dummyquery"/>
    </link>
    <entry>
-      <fullUrl value="urn:uuid:380dd437-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9dd3-621b-11ee-1177-020000000000"/>
       <resource>
          <MedicationRequest>
             <meta>
@@ -100,7 +100,7 @@
                <display value="ACETYLSALICYLZUUR TABLETMSR 100MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
             <authoredOn value="2018-09-02T11:25:00+02:00"/>
@@ -108,7 +108,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:380dd43c-e371-11ed-2910-020000000000"/>
+                        <reference value="urn:uuid:075f9dd8-621b-11ee-1177-020000000000"/>
                         <display value="Peter van Pulver || Huisartsen, niet nader gespecificeerd || Huisartsenpraktijk Pulver &amp; Partners"/>
                      </valueReference>
                   </extension>
@@ -147,7 +147,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd466-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9e02-621b-11ee-1177-020000000000"/>
       <resource>
          <MedicationRequest>
             <meta>
@@ -237,7 +237,7 @@
                <display value="ACETYLSALICYLZUUR TABLETMSR 100MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
             <authoredOn value="2018-09-03T09:00:00+02:00"/>
@@ -245,7 +245,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:380dd46a-e371-11ed-2910-020000000000"/>
+                        <reference value="urn:uuid:075f9e06-621b-11ee-1177-020000000000"/>
                         <display value="Bertine van Doorn || Huisartsen, niet nader gespecificeerd || Huisartsenpraktijk Pulver &amp; Partners"/>
                      </valueReference>
                   </extension>
@@ -284,7 +284,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd4f9-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9021-621b-11ee-1177-020000000000"/>
       <resource>
          <MedicationRequest>
             <meta>
@@ -385,7 +385,7 @@
                <display value="FUROSEMIDE TABLET 40MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
             <authoredOn value="2018-09-03T14:32:00+02:00"/>
@@ -393,7 +393,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:380dd4fe-e371-11ed-2910-020000000000"/>
+                        <reference value="urn:uuid:075f9026-621b-11ee-1177-020000000000"/>
                         <display value="Hans van Doorn || Medisch specialisten, inwendige geneeskunde || Ziekenhuis Stitswerd"/>
                      </valueReference>
                   </extension>
@@ -442,7 +442,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd52a-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9052-621b-11ee-1177-020000000000"/>
       <resource>
          <MedicationRequest>
             <meta>
@@ -556,7 +556,7 @@
                <display value="METHOTREXAAT TABLET 2,5MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
             <authoredOn value="2018-09-03T14:32:00+02:00"/>
@@ -564,7 +564,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:380dd4fe-e371-11ed-2910-020000000000"/>
+                        <reference value="urn:uuid:075f9026-621b-11ee-1177-020000000000"/>
                         <display value="Hans van Doorn || Medisch specialisten, inwendige geneeskunde || Ziekenhuis Stitswerd"/>
                      </valueReference>
                   </extension>
@@ -580,7 +580,7 @@
                </coding>
             </reasonCode>
             <reasonReference>
-               <reference value="urn:uuid:380dd545-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f906d-621b-11ee-1177-020000000000"/>
                <display value="Andere maligniteit bloed/lymfestelsel"/>
             </reasonReference>
             <dosageInstruction>
@@ -614,7 +614,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd55e-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9086-621b-11ee-1177-020000000000"/>
       <resource>
          <MedicationRequest>
             <meta>
@@ -728,15 +728,15 @@
                <display value="FENETICILLINE CAPSULE 500MG"/>
             </medicationReference>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
             <supportingInformation>
-               <reference value="urn:uuid:380dd588-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f90b0-621b-11ee-1177-020000000000"/>
                <display value="Lengte: 155 cm. Datum/tijd gemeten: 29 AUG, 2018 09:35"/>
             </supportingInformation>
             <supportingInformation>
-               <reference value="urn:uuid:380dd58b-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f90b3-621b-11ee-1177-020000000000"/>
                <display value="Gewicht: 54 kg. Datum/tijd gemeten: 29 AUG, 2018 09:35"/>
             </supportingInformation>
             <authoredOn value="2018-08-29T09:35:00+02:00"/>
@@ -744,7 +744,7 @@
                <agent>
                   <extension url="http://nictiz.nl/fhir/StructureDefinition/practitionerrole-reference">
                      <valueReference>
-                        <reference value="urn:uuid:380dd43c-e371-11ed-2910-020000000000"/>
+                        <reference value="urn:uuid:075f9dd8-621b-11ee-1177-020000000000"/>
                         <display value="Peter van Pulver || Huisartsen, niet nader gespecificeerd || Huisartsenpraktijk Pulver &amp; Partners"/>
                      </valueReference>
                   </extension>
@@ -786,7 +786,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
       <resource>
          <Patient>
             <meta>
@@ -852,6 +852,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 000001111 (UZI-NR-PERS), <span title="Naamsamenstelling: Eigennaam">Peter van Pulver</span>
                   </div>
+                  <div>Dorpsstraat 1, 1234AA Ons Dorp (WP)</div>
                </div>
             </text>
             <identifier>
@@ -876,6 +877,28 @@
                   </extension>
                </given>
             </name>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation-AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Dorpsstraat 1">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Dorpsstraat"/>
+                  </extension>
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                     <valueString value="1"/>
+                  </extension>
+               </line>
+               <city value="Ons Dorp"/>
+               <postalCode value="1234AA"/>
+            </address>
          </Practitioner>
       </resource>
       <search>
@@ -895,6 +918,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 000001112 (UZI-NR-PERS), <span title="Naamsamenstelling: Eigennaam">Bertine van Doorn</span>
                   </div>
+                  <div>Dorpsstraat 1, 1234AA Ons Dorp (WP)</div>
                </div>
             </text>
             <identifier>
@@ -919,6 +943,28 @@
                   </extension>
                </given>
             </name>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation-AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Dorpsstraat 1">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Dorpsstraat"/>
+                  </extension>
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                     <valueString value="1"/>
+                  </extension>
+               </line>
+               <city value="Ons Dorp"/>
+               <postalCode value="1234AA"/>
+            </address>
          </Practitioner>
       </resource>
       <search>
@@ -938,6 +984,7 @@
                <div xmlns="http://www.w3.org/1999/xhtml">
                   <div>Id 999001112 (UZI-NR-PERS), <span title="Naamsamenstelling: Eigennaam">Hans van Doorn</span>
                   </div>
+                  <div>Dorpsstraat 1, 1234AA Ons Dorp (WP)</div>
                </div>
             </text>
             <identifier>
@@ -962,6 +1009,28 @@
                   </extension>
                </given>
             </name>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/zib-AddressInformation-AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://hl7.org/fhir/v3/AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Dorpsstraat 1">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Dorpsstraat"/>
+                  </extension>
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                     <valueString value="1"/>
+                  </extension>
+               </line>
+               <city value="Ons Dorp"/>
+               <postalCode value="1234AA"/>
+            </address>
          </Practitioner>
       </resource>
       <search>
@@ -1087,7 +1156,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd43c-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9dd8-621b-11ee-1177-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -1142,7 +1211,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd46a-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9e06-621b-11ee-1177-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -1197,7 +1266,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd4fe-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f9026-621b-11ee-1177-020000000000"/>
       <resource>
          <PractitionerRole>
             <meta>
@@ -1420,7 +1489,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd588-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f90b0-621b-11ee-1177-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1467,7 +1536,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
             <effectiveDateTime value="2018-08-29T09:35:00+02:00"/>
@@ -1490,7 +1559,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd58b-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f90b3-621b-11ee-1177-020000000000"/>
       <resource>
          <Observation>
             <meta>
@@ -1537,7 +1606,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
             <effectiveDateTime value="2018-08-29T09:35:00+02:00"/>
@@ -1560,7 +1629,7 @@
       </search>
    </entry>
    <entry>
-      <fullUrl value="urn:uuid:380dd545-e371-11ed-2910-020000000000"/>
+      <fullUrl value="urn:uuid:075f906d-621b-11ee-1177-020000000000"/>
       <resource>
          <Condition>
             <meta>
@@ -1591,7 +1660,7 @@
                </coding>
             </code>
             <subject>
-               <reference value="urn:uuid:380dc480-e371-11ed-2910-020000000000"/>
+               <reference value="urn:uuid:075f8ba6-621b-11ee-1177-020000000000"/>
                <display value="J. XXX_Amaya"/>
             </subject>
          </Condition>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/alerts_REPC_IN990121NL_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/alerts_REPC_IN990121NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.54652+02:00"
-         last-update-date="2023-04-25T15:58:09.54652+02:00"/>
+         creation-date="2023-10-03T20:31:08.780483+02:00"
+         last-update-date="2023-10-03T20:31:08.780483+02:00"/>
    <data>
       <alerts_response app="ketenzorg3.0"
                        shortName="alerts_response"
@@ -16,7 +16,7 @@
                        prefix="kz-"
                        language="en-US"
                        title="Generated Through Conversion"
-                       id="36053297-e371-11ed-1316-020000000000">
+                       id="054fb545-621b-11ee-1908-020000000000">
          <bundle>
             <type code="74018-3"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -67,7 +67,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_POOB_IN990003NL_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_POOB_IN990003NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.466989+02:00"
-         last-update-date="2023-04-25T15:58:09.466989+02:00"/>
+         creation-date="2023-10-03T20:31:08.699481+02:00"
+         last-update-date="2023-10-03T20:31:08.699481+02:00"/>
    <data>
       <general_measurements_response app="ketenzorg3.0"
                                      shortName="general_measurements_response"
@@ -16,7 +16,7 @@
                                      prefix="kz-"
                                      language="en-US"
                                      title="Generated Through Conversion"
-                                     id="35f8f3c3-e371-11ed-1288-020000000000">
+                                     id="05433cfb-621b-11ee-2324-020000000000">
          <bundle>
             <type code="27899-4"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_bundle_POOB_IN990003NL_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/algemene_bepalingen_bundle_POOB_IN990003NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.475979+02:00"
-         last-update-date="2023-04-25T15:58:09.475979+02:00"/>
+         creation-date="2023-10-03T20:31:08.708795+02:00"
+         last-update-date="2023-10-03T20:31:08.708795+02:00"/>
    <data>
       <general_measurements_response app="ketenzorg3.0"
                                      shortName="general_measurements_response"
@@ -16,7 +16,7 @@
                                      prefix="kz-"
                                      language="en-US"
                                      title="Generated Through Conversion"
-                                     id="35fa5b92-e371-11ed-1934-020000000000">
+                                     id="0544b172-621b-11ee-1373-020000000000">
          <bundle>
             <type code="27899-4"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_EX990131NL_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_EX990131NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.826552+02:00"
-         last-update-date="2023-04-25T15:58:08.826552+02:00"/>
+         creation-date="2023-10-03T20:31:08.057887+02:00"
+         last-update-date="2023-10-03T20:31:08.057887+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="35973a9b-e371-11ed-1040-020000000000">
+                                    id="04e156a1-621b-11ee-1044-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_IN990131NL_02.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_REPC_IN990131NL_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.842053+02:00"
-         last-update-date="2023-04-25T15:58:08.842053+02:00"/>
+         creation-date="2023-10-03T20:31:08.075842+02:00"
+         last-update-date="2023-10-03T20:31:08.075842+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="3599b070-e371-11ed-1691-020000000000">
+                                    id="04e42c52-621b-11ee-1588-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -78,7 +78,7 @@
                         <house_number value="15"/>
                         <postcode value="4812 XA"/>
                         <place_of_residence value="Breda"/>
-                        <country value="Nederland"/>
+                        <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                         <address_type code="WP"
                                       codeSystem="2.16.840.1.113883.5.1119"
                                       displayName="Work Place"/>
@@ -133,7 +133,7 @@
                         <house_number value="15"/>
                         <postcode value="4812 XA"/>
                         <place_of_residence value="Breda"/>
-                        <country value="Nederland"/>
+                        <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                         <address_type code="WP"
                                       codeSystem="2.16.840.1.113883.5.1119"
                                       displayName="Work Place"/>
@@ -188,7 +188,7 @@
                         <house_number value="15"/>
                         <postcode value="4812 XA"/>
                         <place_of_residence value="Breda"/>
-                        <country value="Nederland"/>
+                        <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                         <address_type code="WP"
                                       codeSystem="2.16.840.1.113883.5.1119"
                                       displayName="Work Place"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.8592+02:00"
-         last-update-date="2023-04-25T15:58:08.8592+02:00"/>
+         creation-date="2023-10-03T20:31:08.092185+02:00"
+         last-update-date="2023-10-03T20:31:08.092185+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="359c42e2-e371-11ed-9796-020000000000">
+                                    id="04e69f5c-621b-11ee-1315-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -91,7 +91,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="359c438c-e371-11ed-9796-020000000000">
+                                    id="04e6a006-621b-11ee-1315-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_02.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/allergieintoleranties_bundle_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.867775+02:00"
-         last-update-date="2023-04-25T15:58:08.867775+02:00"/>
+         creation-date="2023-10-03T20:31:08.101566+02:00"
+         last-update-date="2023-10-03T20:31:08.101566+02:00"/>
    <data>
       <allergyintolerances_response app="ketenzorg3.0"
                                     shortName="allergyintolerances_response"
@@ -16,7 +16,7 @@
                                     prefix="kz-"
                                     language="en-US"
                                     title="Generated Through Conversion"
-                                    id="359da142-e371-11ed-5385-020000000000">
+                                    id="04e81d38-621b-11ee-5176-020000000000">
          <bundle>
             <type code="48765-2"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.628814+02:00"
-         last-update-date="2023-04-25T15:58:09.628814+02:00"/>
+         creation-date="2023-10-03T20:31:08.86284+02:00"
+         last-update-date="2023-10-03T20:31:08.86284+02:00"/>
    <data>
       <encounters_response app="ketenzorg3.0"
                            shortName="encounters_response"
@@ -16,7 +16,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="3611a50d-e371-11ed-1057-020000000000">
+                           id="055c2a31-621b-11ee-1544-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_02_HACONTMOM.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactmomenten_PRPA_IN900350NL_02_HACONTMOM.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.632313+02:00"
-         last-update-date="2023-04-25T15:58:09.632313+02:00"/>
+         creation-date="2023-10-03T20:31:08.865887+02:00"
+         last-update-date="2023-10-03T20:31:08.865887+02:00"/>
    <data>
       <encounters_response app="ketenzorg3.0"
                            shortName="encounters_response"
@@ -16,7 +16,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="3612421a-e371-11ed-6699-020000000000">
+                           id="055cb596-621b-11ee-1562-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.094922+02:00"
-         last-update-date="2023-04-25T15:58:09.094922+02:00"/>
+         creation-date="2023-10-03T20:31:08.33276+02:00"
+         last-update-date="2023-10-03T20:31:08.33276+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c02de5-e371-11ed-2519-020000000000">
+                                id="050b47f1-621b-11ee-2715-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_02.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.105445+02:00"
-         last-update-date="2023-04-25T15:58:09.105445+02:00"/>
+         creation-date="2023-10-03T20:31:08.341744+02:00"
+         last-update-date="2023-10-03T20:31:08.341744+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c1dc61-e371-11ed-8716-020000000000">
+                                id="050cba4f-621b-11ee-7631-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_03.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_REPC_IN990101NL_03.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.133408+02:00"
-         last-update-date="2023-04-25T15:58:09.133408+02:00"/>
+         creation-date="2023-10-03T20:31:08.364587+02:00"
+         last-update-date="2023-10-03T20:31:08.364587+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c61239-e371-11ed-2104-020000000000">
+                                id="05102827-621b-11ee-1112-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_01_met_contacten.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_01_met_contacten.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.151987+02:00"
-         last-update-date="2023-04-25T15:58:09.151987+02:00"/>
+         creation-date="2023-10-03T20:31:08.382636+02:00"
+         last-update-date="2023-10-03T20:31:08.382636+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35c8ef8e-e371-11ed-1862-020000000000">
+                                id="0512f0c8-621b-11ee-7464-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>
@@ -83,7 +83,8 @@
                </author>
                <date_time value="2019-01-30T16:45:00"/>
             </hcimroot>
-            <encounter value="996625" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+            <encounter value="d8db035c-6214-11ee-5414-020000000000"
+                       root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             <episode value="1826" root="2.16.840.1.113883.2.4.6.6.90000258.4.6"/>
             <journal_entry>
                <type value="1"
@@ -241,7 +242,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="35c8f131-e371-11ed-1862-020000000000">
+                           id="0512f26b-621b-11ee-7464-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -272,7 +273,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>
@@ -285,7 +286,8 @@
          </bundle>
          <encounter>
             <hcimroot>
-               <identification_number value="996625" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+               <identification_number value="d8db035c-6214-11ee-5414-020000000000"
+                                      root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
             </hcimroot>
             <contact_type code="03"
                           codeSystem="2.16.840.1.113883.2.4.4.30.14"

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_02_met_contacten.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_02_met_contacten.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.160854+02:00"
-         last-update-date="2023-04-25T15:58:09.160854+02:00"/>
+         creation-date="2023-10-03T20:31:08.392819+02:00"
+         last-update-date="2023-10-03T20:31:08.392819+02:00"/>
    <data>
       <encounters_response app="ketenzorg3.0"
                            shortName="encounters_response"
@@ -16,7 +16,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="35ca5d70-e371-11ed-6278-020000000000">
+                           id="05149212-621b-11ee-9563-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_03_met_contacten.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/contactverslag_bundle_03_met_contacten.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.173146+02:00"
-         last-update-date="2023-04-25T15:58:09.173146+02:00"/>
+         creation-date="2023-10-03T20:31:08.405359+02:00"
+         last-update-date="2023-10-03T20:31:08.405359+02:00"/>
    <data>
       <encounter_notes_response app="ketenzorg3.0"
                                 shortName="encounter_notes_response"
@@ -16,7 +16,7 @@
                                 prefix="kz-"
                                 language="en-US"
                                 title="Generated Through Conversion"
-                                id="35cc1ee9-e371-11ed-1921-020000000000">
+                                id="05165d3b-621b-11ee-1396-020000000000">
          <bundle>
             <type code="34900-1"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>
@@ -1110,7 +1110,7 @@
                            prefix="kz-"
                            language="en-US"
                            title="Generated Through Conversion"
-                           id="35cc2628-e371-11ed-1921-020000000000">
+                           id="0516647a-621b-11ee-1396-020000000000">
          <bundle>
             <type code="46240-8"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -1141,7 +1141,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/diagnostische_bepalingen_bundle_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/diagnostische_bepalingen_bundle_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.293424+02:00"
-         last-update-date="2023-04-25T15:58:09.293424+02:00"/>
+         creation-date="2023-10-03T20:31:08.525502+02:00"
+         last-update-date="2023-10-03T20:31:08.525502+02:00"/>
    <data>
       <lab_results_response app="ketenzorg3.0"
                             shortName="lab_results_response"
@@ -16,7 +16,7 @@
                             prefix="kz-"
                             language="en-US"
                             title="Generated Through Conversion"
-                            id="35de78bb-e371-11ed-1875-020000000000">
+                            id="0528b1c7-621b-11ee-1863-020000000000">
          <bundle>
             <type code="26436-6"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>
@@ -210,7 +210,7 @@
                                      prefix="kz-"
                                      language="en-US"
                                      title="Generated Through Conversion"
-                                     id="35de9411-e371-11ed-1875-020000000000">
+                                     id="0528cd1d-621b-11ee-1863-020000000000">
          <bundle>
             <type code="27899-4"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -241,7 +241,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.986492+02:00"
-         last-update-date="2023-04-25T15:58:08.986492+02:00"/>
+         creation-date="2023-10-03T20:31:08.223927+02:00"
+         last-update-date="2023-10-03T20:31:08.223927+02:00"/>
    <data>
       <episodes_response app="ketenzorg3.0"
                          shortName="episodes_response"
@@ -16,7 +16,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35afa241-e371-11ed-3518-020000000000">
+                         id="04faac8f-621b-11ee-1241-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_02.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_REPC_EX990111NL_02.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.991311+02:00"
-         last-update-date="2023-04-25T15:58:08.991311+02:00"/>
+         creation-date="2023-10-03T20:31:08.2284+02:00"
+         last-update-date="2023-10-03T20:31:08.2284+02:00"/>
    <data>
       <episodes_response app="ketenzorg3.0"
                          shortName="episodes_response"
@@ -16,7 +16,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35b0673e-e371-11ed-1673-020000000000">
+                         id="04fb6408-621b-11ee-1720-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1003"/>
                      <postcode value="9999 ZA"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                   </address_information>
                   <patient_identification_number value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
                   <date_of_birth value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_bundle_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/episodes_bundle_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:08.995434+02:00"
-         last-update-date="2023-04-25T15:58:08.995434+02:00"/>
+         creation-date="2023-10-03T20:31:08.23238+02:00"
+         last-update-date="2023-10-03T20:31:08.23238+02:00"/>
    <data>
       <episodes_response app="ketenzorg3.0"
                          shortName="episodes_response"
@@ -16,7 +16,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35b100d3-e371-11ed-1497-020000000000">
+                         id="04fbf807-621b-11ee-5319-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -102,7 +102,7 @@
                          prefix="kz-"
                          language="en-US"
                          title="Generated Through Conversion"
-                         id="35b1016a-e371-11ed-1497-020000000000">
+                         id="04fbf89e-621b-11ee-5319-020000000000">
          <bundle>
             <type code="75310-3"
                   codeSystem="2.16.840.1.113883.6.1"

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/labbepalingen_POLB_IN364001NL03_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/labbepalingen_POLB_IN364001NL03_01.xml
@@ -4,8 +4,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.38439+02:00"
-         last-update-date="2023-04-25T15:58:09.38439+02:00"/>
+         creation-date="2023-10-03T20:31:08.621355+02:00"
+         last-update-date="2023-10-03T20:31:08.621355+02:00"/>
    <data>
       <lab_results_response app="ketenzorg3.0"
                             shortName="lab_results_response"
@@ -16,7 +16,7 @@
                             prefix="kz-"
                             language="en-US"
                             title="Generated Through Conversion"
-                            id="35ec593d-e371-11ed-5715-020000000000">
+                            id="0537512f-621b-11ee-7697-020000000000">
          <bundle>
             <type code="26436-6"
                   codeSystem="2.16.840.1.113883.6.1"
@@ -47,7 +47,7 @@
                      <house_number value="1001"/>
                      <postcode value="9999 XX"/>
                      <place_of_residence value="STITSWERD"/>
-                     <country value="Nederland"/>
+                     <country code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                      <address_type code="HP"
                                    codeSystem="2.16.840.1.113883.5.1119"
                                    displayName="Primary Home"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_Kwalificatie.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_Kwalificatie.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.907535+02:00"
-         last-update-date="2023-04-25T15:58:09.907535+02:00"/>
+         creation-date="2023-10-03T20:31:09.192271+02:00"
+         last-update-date="2023-10-03T20:31:09.192271+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363c2f74-e371-11ed-1687-020000000000">
+                                             id="058e7174-621b-11ee-2122-020000000000">
          <patient>
             <naamgegevens>
                <initialen value="E."/>
@@ -33,7 +33,7 @@
                <huisnummer value="1001"/>
                <postcode value="9999 XX"/>
                <woonplaats value="STITSWERD"/>
-               <land value="Nederland"/>
+               <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                <adres_soort code="HP"
                             codeSystem="2.16.840.1.113883.5.1119"
                             displayName="Primary Home"/>
@@ -88,7 +88,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -178,7 +178,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -278,7 +278,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -370,7 +370,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -459,7 +459,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -556,7 +556,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>
@@ -646,7 +646,7 @@
                            <straat value="Valkendael 45"/>
                            <postcode value="6245 HK"/>
                            <woonplaats value="Maastricht"/>
-                           <land value="Nederland"/>
+                           <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
                            <adres_soort code="WP"
                                         codeSystem="2.16.840.1.113883.5.1119"
                                         displayName="Werkadres"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_01.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_01.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.915954+02:00"
-         last-update-date="2023-04-25T15:58:09.915954+02:00"/>
+         creation-date="2023-10-03T20:31:09.200749+02:00"
+         last-update-date="2023-10-03T20:31:09.200749+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363d8bdd-e371-11ed-1699-020000000000">
+                                             id="058fd02b-621b-11ee-9007-020000000000">
          <patient>
             <naamgegevens>
                <voornamen value="Joris"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_02.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_QUMA_IN991203NL02_02.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.91819+02:00"
-         last-update-date="2023-04-25T15:58:09.91819+02:00"/>
+         creation-date="2023-10-03T20:31:09.202858+02:00"
+         last-update-date="2023-10-03T20:31:09.202858+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363de537-e371-11ed-1957-020000000000">
+                                             id="0590248f-621b-11ee-9712-020000000000">
          <patient>
             <naamgegevens>
                <initialen value="H."/>
@@ -33,7 +33,7 @@
                <huisnummer value="1003"/>
                <postcode value="9999 ZA"/>
                <woonplaats value="STITSWERD"/>
-               <land value="Nederland"/>
+               <land code="NL" codeSystem="1.0.3166.1.2.2" displayName="Nederland"/>
             </adresgegevens>
             <identificatienummer value="900184590" root="2.16.840.1.113883.2.4.6.3"/>
             <geboortedatum value="1985-12-30"/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_XXX_Amaya-907.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/ada_instance/medicatieafspraken_XXX_Amaya-907.xml
@@ -5,8 +5,8 @@
    <meta status="new"
          created-by="generated"
          last-update-by="generated"
-         creation-date="2023-04-25T15:58:09.920431+02:00"
-         last-update-date="2023-04-25T15:58:09.920431+02:00"/>
+         creation-date="2023-10-03T20:31:09.204816+02:00"
+         last-update-date="2023-10-03T20:31:09.204816+02:00"/>
    <data>
       <beschikbaarstellen_medicatieafspraken app="ketenzorg3.0"
                                              shortName="beschikbaarstellen_medicatieafspraken"
@@ -17,7 +17,7 @@
                                              prefix="kz-"
                                              language="nl-NL"
                                              title="Generated Through Conversion"
-                                             id="363e23f8-e371-11ed-1019-020000000000">
+                                             id="05905842-621b-11ee-1997-020000000000">
          <patient>
             <naamgegevens>
                <initialen value="J."/>

--- a/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/hl7v3_instance/contactverslag_bundle_01_met_contacten.xml
+++ b/hl7_2_ada/ketenzorg/3.0.2/beschikbaarstellen/hl7v3_instance/contactverslag_bundle_01_met_contacten.xml
@@ -103,7 +103,7 @@
                                     </participant>
                                     <entryRelationship typeCode="REFR">
                                         <encounter classCode="ENC" moodCode="EVN">
-                                            <id extension="996625" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+                                            <id extension="d8db035c-6214-11ee-5414-020000000000" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
                                         </encounter>
                                     </entryRelationship>
                                     <entryRelationship typeCode="REFR">
@@ -328,7 +328,7 @@
                             <component contextControlCode="OP" typeCode="COMP">
                                 <encounter classCode="ENC" moodCode="EVN">
                                     <templateId root="2.16.840.1.113883.2.4.3.11.60.66.10.201"/>
-                                    <id extension="996625" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
+                                    <id extension="d8db035c-6214-11ee-5414-020000000000" root="2.16.840.1.113883.2.4.6.6.90000258.4.10"/>
                                     <code code="03" codeSystem="2.16.840.1.113883.2.4.4.30.14" codeSystemName="Soort contact" codeSystemVersion="v7" displayName="consult"/>
                                     <effectiveTime>
                                         <low value="201902031645"/>


### PR DESCRIPTION
Now creates Resource.id when input extension is a uuid (was: no Resource.id)
Now creates a legible reference(encounter).display when the Encounter is available (was: "Contact ID: ...")
Fixes journal entry Observation.performer (was missing due to incorrect input path selection)
Adds Composition.author practitionerRole extension (was missing)
